### PR TITLE
Function registry changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,72 @@ Query query = Query.fromString(adapter, "locations[?state == 'WA'].name | sort(@
 JsonNode result = query.evaluate(adapter, input);
 ```
 
+### Adding custom functions
+
+In addition to the built in functions like `sort`, `to_string`, and `sum` you can add your own. All you need to do is to create a class that extends `io.burt.jmespath.function.JmesPathFunction` and then register it with your adapter.
+
+Here's how you add a `sin` function:
+
+```java
+import java.util.List;
+
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.function.ArgumentConstraints;
+import io.burt.jmespath.function.ExpressionOrValue;
+import io.burt.jmespath.function.JmesPathFunction;
+
+// Functions must extend JmesPathFunction
+public class SinFunction extends JmesPathFunction {
+  public SinFunction() {
+    // This is how you tell the type checker what arguments your function accepts
+    super(ArgumentConstraints.typeOf(JmesPathType.NUMBER);
+  }
+
+  @Override
+  protected <T> T callFunction(Adapter<T> adapter, List<ExpressionOrValue<T>> arguments) {
+    // Arguments can be either values or expressions, but most functions only
+    // accept expressions. You don't need to do any type checking here, the
+    // the runtime has made sure that if this code runs the types are correct.
+    T value = arguments.get(0).value();
+    // Since we want to be able to use this function with all types of inputs
+    // it needs to use the adapter to convert data types.
+    double n = adapter.toNumber(value).doubleValue();
+    // This is the actual function, the rest is wrapping, that's the price of
+    // being generic and supporting multiple implementations.
+    // There are abstract classes in the io.burt.jmespath.function
+    // package that can be used to avoid having to write all of the wrapping
+    // for some types of functions. This function could extend MathFunction,
+    // for example.
+    double s = Math.sin(n);
+    // We must not forget to wrap the result using the adapter.
+    return adapter.createNumber(s);
+  }
+}
+
+// …
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.burt.jmespath.Query;
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.jackson.JacksonAdapter;
+
+// There's a default registry that contains the built in JMESPath functions
+FunctionRegistry defaultFunctions = FunctionRegistry.defaultRegistry();
+// And we can create a new registry with additional functions by extending it
+FunctionRegistry customFunctions = defaultFunctions.extend(new SinFunction());
+// We need to tell the adapter to use our custom registry
+Adapter<JsonNode> adapter = new JacksonAdapter(functionRegistry);
+// Now the function is available in expressions
+JsonNode result = Query.fromString(adapter, "sin(measurements.angle)").evaluate(adapter, input);
+```
+
+You can provide a name for your function, but the default is that the name will be the snake cased version of the class name, minus the "Function" suffix. `SinFunction` becomes `sin`, `MyAwesomeFunction` becomes `my_awesome`, etc.
+
+Your function class needs to tell the runtime about what arguments it accepts. The function in the example above specifies that it accepts a single number as argument. Have a look at the existing functions and the documentation for the `ArgumentConstraints` DSL to see what is possible.
+
 ## How to build and run the tests
 
 The best place to see how to build and run the tests is to look at the `.travis.yml` file, but if you just want to get going run:

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseAdapter.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseAdapter.java
@@ -20,14 +20,18 @@ public abstract class BaseAdapter<T> implements Adapter<T> {
    * Create a new adapter with a default function registry.
    */
   public BaseAdapter() {
-    this(FunctionRegistry.createDefaultRegistry());
+    this(null);
   }
 
   /**
    * Create a new adapter with a custom function registry.
    */
   public BaseAdapter(FunctionRegistry functionRegistry) {
-    this.functionRegistry = functionRegistry;
+    if (functionRegistry == null) {
+      this.functionRegistry = FunctionRegistry.createDefaultRegistry();
+    } else {
+      this.functionRegistry = functionRegistry;
+    }
   }
 
   /**

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseAdapter.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseAdapter.java
@@ -28,7 +28,7 @@ public abstract class BaseAdapter<T> implements Adapter<T> {
    */
   public BaseAdapter(FunctionRegistry functionRegistry) {
     if (functionRegistry == null) {
-      this.functionRegistry = FunctionRegistry.createDefaultRegistry();
+      this.functionRegistry = FunctionRegistry.defaultRegistry();
     } else {
       this.functionRegistry = functionRegistry;
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
@@ -50,6 +50,10 @@ public class FunctionRegistry {
     return defaultRegistry;
   }
 
+  /**
+   * Creates a new function registry containing the specified functions.
+   * When there are multiple functions with the same name the last one is used.
+   */
   public FunctionRegistry(JmesPathFunction... functions) {
     this.functions = new HashMap<>();
     for (JmesPathFunction function : functions) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
@@ -11,41 +11,43 @@ import io.burt.jmespath.Adapter;
  * by name.
  */
 public class FunctionRegistry {
+  private final static FunctionRegistry defaultRegistry = new FunctionRegistry(
+    new AbsFunction(),
+    new AvgFunction(),
+    new ContainsFunction(),
+    new CeilFunction(),
+    new EndsWithFunction(),
+    new FloorFunction(),
+    new JoinFunction(),
+    new KeysFunction(),
+    new LengthFunction(),
+    new MapFunction(),
+    new MaxFunction(),
+    new MaxByFunction(),
+    new MergeFunction(),
+    new MinFunction(),
+    new MinByFunction(),
+    new NotNullFunction(),
+    new ReverseFunction(),
+    new SortFunction(),
+    new SortByFunction(),
+    new StartsWithFunction(),
+    new SumFunction(),
+    new ToArrayFunction(),
+    new ToStringFunction(),
+    new ToNumberFunction(),
+    new TypeFunction(),
+    new ValuesFunction()
+  );
+
   private final Map<String, JmesPathFunction> functions;
 
   /**
-   * Create a registry with the the functions specified in the JMESPath
+   * Returns a registry with all the the functions specified in the JMESPath
    * specification.
    */
-  public static FunctionRegistry createDefaultRegistry() {
-    return new FunctionRegistry(
-      new AbsFunction(),
-      new AvgFunction(),
-      new ContainsFunction(),
-      new CeilFunction(),
-      new EndsWithFunction(),
-      new FloorFunction(),
-      new JoinFunction(),
-      new KeysFunction(),
-      new LengthFunction(),
-      new MapFunction(),
-      new MaxFunction(),
-      new MaxByFunction(),
-      new MergeFunction(),
-      new MinFunction(),
-      new MinByFunction(),
-      new NotNullFunction(),
-      new ReverseFunction(),
-      new SortFunction(),
-      new SortByFunction(),
-      new StartsWithFunction(),
-      new SumFunction(),
-      new ToArrayFunction(),
-      new ToStringFunction(),
-      new ToNumberFunction(),
-      new TypeFunction(),
-      new ValuesFunction()
-    );
+  public static FunctionRegistry defaultRegistry() {
+    return defaultRegistry;
   }
 
   public FunctionRegistry(JmesPathFunction... functions) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
@@ -55,8 +55,12 @@ public class FunctionRegistry {
    * When there are multiple functions with the same name the last one is used.
    */
   public FunctionRegistry(JmesPathFunction... functions) {
-    this.functions = new HashMap<>();
-    for (JmesPathFunction function : functions) {
+    this(null, functions);
+  }
+
+  private FunctionRegistry(Map<String, JmesPathFunction> functions0, JmesPathFunction... functions1) {
+    this.functions = functions0 == null ? new HashMap<String, JmesPathFunction>() : new HashMap<String, JmesPathFunction>(functions0);
+    for (JmesPathFunction function : functions1) {
       this.functions.put(function.name(), function);
     }
   }
@@ -75,5 +79,14 @@ public class FunctionRegistry {
     } else {
       throw new FunctionCallException(String.format("Unknown function: \"%s\"", functionName));
     }
+  }
+
+  /**
+   * Creates a new function registry that contains all the functions of this
+   * registry and the specified functions. When a new function has the same name
+   * as one of the functions in this registry, the new function will be used.
+   */
+  public FunctionRegistry extend(JmesPathFunction... functions) {
+    return new FunctionRegistry(this.functions, functions);
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/FunctionRegistry.java
@@ -18,42 +18,41 @@ public class FunctionRegistry {
    * specification.
    */
   public static FunctionRegistry createDefaultRegistry() {
-    FunctionRegistry registry = new FunctionRegistry();
-    registry.add(new AbsFunction());
-    registry.add(new AvgFunction());
-    registry.add(new ContainsFunction());
-    registry.add(new CeilFunction());
-    registry.add(new EndsWithFunction());
-    registry.add(new FloorFunction());
-    registry.add(new JoinFunction());
-    registry.add(new KeysFunction());
-    registry.add(new LengthFunction());
-    registry.add(new MapFunction());
-    registry.add(new MaxFunction());
-    registry.add(new MaxByFunction());
-    registry.add(new MergeFunction());
-    registry.add(new MinFunction());
-    registry.add(new MinByFunction());
-    registry.add(new NotNullFunction());
-    registry.add(new ReverseFunction());
-    registry.add(new SortFunction());
-    registry.add(new SortByFunction());
-    registry.add(new StartsWithFunction());
-    registry.add(new SumFunction());
-    registry.add(new ToArrayFunction());
-    registry.add(new ToStringFunction());
-    registry.add(new ToNumberFunction());
-    registry.add(new TypeFunction());
-    registry.add(new ValuesFunction());
-    return registry;
+    return new FunctionRegistry(
+      new AbsFunction(),
+      new AvgFunction(),
+      new ContainsFunction(),
+      new CeilFunction(),
+      new EndsWithFunction(),
+      new FloorFunction(),
+      new JoinFunction(),
+      new KeysFunction(),
+      new LengthFunction(),
+      new MapFunction(),
+      new MaxFunction(),
+      new MaxByFunction(),
+      new MergeFunction(),
+      new MinFunction(),
+      new MinByFunction(),
+      new NotNullFunction(),
+      new ReverseFunction(),
+      new SortFunction(),
+      new SortByFunction(),
+      new StartsWithFunction(),
+      new SumFunction(),
+      new ToArrayFunction(),
+      new ToStringFunction(),
+      new ToNumberFunction(),
+      new TypeFunction(),
+      new ValuesFunction()
+    );
   }
 
-  public FunctionRegistry() {
+  public FunctionRegistry(JmesPathFunction... functions) {
     this.functions = new HashMap<>();
-  }
-
-  public void add(JmesPathFunction function) {
-    functions.put(function.name(), function);
+    for (JmesPathFunction function : functions) {
+      this.functions.put(function.name(), function);
+    }
   }
 
   /**

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/MathFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/MathFunction.java
@@ -12,19 +12,9 @@ public abstract class MathFunction extends JmesPathFunction {
 
   @Override
   protected <T> T callFunction(Adapter<T> adapter, List<ExpressionOrValue<T>> arguments) {
-    ExpressionOrValue<T> argument = arguments.get(0);
-    if (argument.isExpression()) {
-      throw new ArgumentTypeException(name(), "number", "expression");
-    } else {
-      T value = argument.value();
-      JmesPathType type = adapter.typeOf(value);
-      if (type == JmesPathType.NUMBER) {
-        double n = adapter.toNumber(value).doubleValue();
-        return adapter.createNumber(performMathOperation(n));
-      } else {
-        throw new ArgumentTypeException(name(), "number", type.toString());
-      }
-    }
+    T value = arguments.get(0).value();
+    double n = adapter.toNumber(value).doubleValue();
+    return adapter.createNumber(performMathOperation(n));
   }
 
   protected abstract double performMathOperation(double n);

--- a/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfAdapter.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfAdapter.java
@@ -8,11 +8,20 @@ import java.util.Collections;
 
 import io.burt.jmespath.BaseAdapter;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.function.FunctionRegistry;
 
 import static io.burt.jmespath.JmesPathType.*;
 
 @SuppressWarnings("unchecked")
 public class JcfAdapter extends BaseAdapter<Object> {
+  public JcfAdapter() {
+    super();
+  }
+
+  public JcfAdapter(FunctionRegistry functionRegistry) {
+    super(functionRegistry);
+  }
+
   @Override
   public Object parseString(String string) {
     return JsonParser.fromString(string, this);

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
@@ -79,6 +79,15 @@ public class FunctionRegistryTest {
   }
 
   @Test
+  public void theLastFunctionIsUsedWhenThereAreDuplicatedNames() {
+    FunctionRegistry registry = new FunctionRegistry(
+      new TestFunction("foo", ArgumentConstraints.typeOf(JmesPathType.STRING)),
+      new TestFunction("foo", ArgumentConstraints.typeOf(JmesPathType.NUMBER))
+    );
+    registry.callFunction(adapter, "foo", createValueArguments(3));
+  }
+
+  @Test
   public void callingAMissingFunctionThrowsFunctionCallException() {
     FunctionRegistry registry = FunctionRegistry.defaultRegistry();
     try {

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
@@ -1,0 +1,90 @@
+package io.burt.jmespath.function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.node.ExpressionReferenceNode;
+import io.burt.jmespath.node.PropertyNode;
+import io.burt.jmespath.node.CurrentNode;
+import io.burt.jmespath.jcf.JcfAdapter;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+public class FunctionRegistryTest {
+  private final Adapter<Object> adapter = new JcfAdapter();
+
+  private List<ExpressionOrValue<Object>> createValueArguments(Object... values) {
+    List<ExpressionOrValue<Object>> arguments = new ArrayList<>();
+    for (Object value : values) {
+      arguments.add(new ExpressionOrValue<Object>(value));
+    }
+    return arguments;
+  }
+
+  private static class TestFunction extends JmesPathFunction {
+    public TestFunction(String name, ArgumentConstraint argumentConstraints) {
+      super(name, argumentConstraints);
+    }
+
+    @Override
+    protected <T> T callFunction(Adapter<T> adapter, List<ExpressionOrValue<T>> arguments) {
+      return arguments.get(0).value();
+    }
+  }
+
+  @Test
+  public void theDefaultRegistryContainsTheDefaultFunctions() {
+    FunctionRegistry registry = FunctionRegistry.defaultRegistry();
+    Object result;
+    result = registry.callFunction(adapter, "to_string", createValueArguments(1));
+    assertThat(result, is((Object) "1"));
+    result = registry.callFunction(adapter, "to_number", createValueArguments("1"));
+    assertThat(result, is((Object) 1.0));
+  }
+
+  @Test
+  public void aCustomRegistryDoesNotContainTheDefaultFunctions() {
+    FunctionRegistry registry = new FunctionRegistry(
+      new TestFunction("foo", ArgumentConstraints.typeOf(JmesPathType.STRING))
+    );
+    try {
+      registry.callFunction(adapter, "to_number", createValueArguments(1));
+    } catch (FunctionCallException fce) {
+      assertThat(fce.getMessage(), containsString("Unknown function: \"to_number\""));
+    }
+  }
+
+  @Test
+  public void aCustomRegistryContainsTheProvidedFunctions() {
+    FunctionRegistry registry = new FunctionRegistry(
+      new TestFunction("foo", ArgumentConstraints.typeOf(JmesPathType.STRING)),
+      new TestFunction("bar", ArgumentConstraints.typeOf(JmesPathType.NUMBER))
+    );
+    Object result;
+    result = registry.callFunction(adapter, "foo", createValueArguments("hello"));
+    assertThat(result, is((Object) "hello"));
+    result = registry.callFunction(adapter, "bar", createValueArguments(42));
+    assertThat(result, is((Object) 42));
+  }
+
+  @Test
+  public void callingAMissingFunctionThrowsFunctionCallException() {
+    FunctionRegistry registry = FunctionRegistry.defaultRegistry();
+    try {
+      registry.callFunction(adapter, "foo", createValueArguments(1, 2, 3));
+    } catch (FunctionCallException fce) {
+      assertThat(fce.getMessage(), containsString("Unknown function: \"foo\""));
+    }
+  }
+}

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionRegistryTest.java
@@ -96,4 +96,30 @@ public class FunctionRegistryTest {
       assertThat(fce.getMessage(), containsString("Unknown function: \"foo\""));
     }
   }
+
+  @Test
+  public void extendIsUsedToCreateRegistriesWithExtraFunctions() {
+    FunctionRegistry defaultRegistry = FunctionRegistry.defaultRegistry();
+    FunctionRegistry extendedRegistry = defaultRegistry.extend(
+      new TestFunction("foo", ArgumentConstraints.typeOf(JmesPathType.STRING)),
+      new TestFunction("bar", ArgumentConstraints.typeOf(JmesPathType.NUMBER))
+    );
+    Object result;
+    result = extendedRegistry.callFunction(adapter, "to_number", createValueArguments("3"));
+    assertThat(result, is((Object) 3.0));
+    result = extendedRegistry.callFunction(adapter, "foo", createValueArguments("hello"));
+    assertThat(result, is((Object) "hello"));
+    result = extendedRegistry.callFunction(adapter, "bar", createValueArguments(42));
+    assertThat(result, is((Object) 42));
+  }
+
+  @Test
+  public void functionsCanBeOverriddenWithExtend() {
+    FunctionRegistry defaultRegistry = FunctionRegistry.defaultRegistry();
+    FunctionRegistry extendedRegistry = defaultRegistry.extend(
+      new TestFunction("to_number", ArgumentConstraints.typeOf(JmesPathType.STRING))
+    );
+    Object result = extendedRegistry.callFunction(adapter, "to_number", createValueArguments("hello"));
+    assertThat(result, is((Object) "hello"));
+  }
 }

--- a/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonAdapter.java
+++ b/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonAdapter.java
@@ -16,12 +16,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.burt.jmespath.BaseAdapter;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.function.FunctionRegistry;
 
 public class JacksonAdapter extends BaseAdapter<JsonNode> {
   private final ObjectMapper jsonParser;
 
   public JacksonAdapter() {
-    super();
+    this(null);
+  }
+
+  public JacksonAdapter(FunctionRegistry functionRegistry) {
+    super(functionRegistry);
     this.jsonParser = new ObjectMapper();
   }
 


### PR DESCRIPTION
This makes `FunctionRegistry` immutable, but adds an API to create a custom function registry that has the default functions and extra functions (with the possibility to override default functions).

The current mutable `FunctionRegistry` wasn't even thread safe.

To create a custom function registry with the default functions plus custom functions you do:

```
FunctionRegistry defaultRegistry = FunctionRegistry.defaultRegistry();
FunctionRegistry customRegistry = defaultRegistry.extend(new CustomFunction1(), new CustomFunction2());
```

The adapter implementations now also take a registry as argument, which makes #5 unnecessary.