### PR TITLE
Reorganize AST for top-down evaluation

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/node/AndNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/AndNode.java
@@ -9,15 +9,10 @@ public class AndNode<T> extends OperatorNode<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    T leftResult = operand(0).search(currentValue);
+  public T search(T input) {
+    T leftResult = operand(0).search(input);
     if (runtime.isTruthy(leftResult)) {
-      return operand(1).search(currentValue);
+      return operand(1).search(input);
     } else {
       return leftResult;
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/ComparisonNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/ComparisonNode.java
@@ -4,8 +4,6 @@ import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
 import io.burt.jmespath.JmesPathType;
 
-import static io.burt.jmespath.node.Operator.*;
-
 public abstract class ComparisonNode<T> extends OperatorNode<T> {
   public static class EqualsNode<T> extends ComparisonNode<T> {
     public EqualsNode(Adapter<T> runtime, Expression<T> left, Expression<T> right) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/ComparisonNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/ComparisonNode.java
@@ -135,14 +135,9 @@ public abstract class ComparisonNode<T> extends OperatorNode<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    T leftResult = operand(0).search(currentValue);
-    T rightResult = operand(1).search(currentValue);
+  public T search(T input) {
+    T leftResult = operand(0).search(input);
+    T rightResult = operand(1).search(input);
     JmesPathType leftType = runtime.typeOf(leftResult);
     JmesPathType rightType = runtime.typeOf(rightResult);
     if (leftType == JmesPathType.NUMBER && rightType == JmesPathType.NUMBER) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/CreateArrayNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/CreateArrayNode.java
@@ -11,14 +11,9 @@ import io.burt.jmespath.JmesPathType;
 public class CreateArrayNode<T> extends Node<T> {
   private final List<Expression<T>> entries;
 
-  public CreateArrayNode(Adapter<T> runtime, List<? extends Expression<T>> entries, Node<T> source) {
-    super(runtime, source);
+  public CreateArrayNode(Adapter<T> runtime, List<? extends Expression<T>> entries) {
+    super(runtime);
     this.entries = new ArrayList<>(entries);
-  }
-
-  @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createCreateArray(entries, source);
   }
 
   protected List<Expression<T>> entries() {
@@ -26,13 +21,13 @@ public class CreateArrayNode<T> extends Node<T> {
   }
 
   @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.NULL) {
-      return currentValue;
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.NULL) {
+      return input;
     } else {
       List<T> array = new ArrayList<>();
       for (Expression<T> entry : entries) {
-        array.add(entry.search(currentValue));
+        array.add(entry.search(input));
       }
       return runtime.createArray(array);
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/CreateObjectNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/CreateObjectNode.java
@@ -50,24 +50,19 @@ public class CreateObjectNode<T> extends Node<T> {
     }
   }
 
-  public CreateObjectNode(Adapter<T> runtime, List<Entry<T>> entries, Node<T> source) {
-    super(runtime, source);
+  public CreateObjectNode(Adapter<T> runtime, List<Entry<T>> entries) {
+    super(runtime);
     this.entries = entries;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createCreateObject(entries, source);
-  }
-
-  @Override
-  public T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.NULL) {
-      return currentValue;
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.NULL) {
+      return input;
     } else {
       Map<T, T> object = new LinkedHashMap<>();
       for (Entry<T> entry : entries()) {
-        object.put(runtime.createString(entry.key()), entry.value().search(currentValue));
+        object.put(runtime.createString(entry.key()), entry.value().search(input));
       }
       return runtime.createObject(object);
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/CurrentNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/CurrentNode.java
@@ -4,30 +4,12 @@ import io.burt.jmespath.Adapter;
 
 public class CurrentNode<T> extends Node<T> {
   public CurrentNode(Adapter<T> runtime) {
-    super(runtime, null);
-  }
-
-  public CurrentNode(Adapter<T> runtime, Node<T> source) {
-    super(runtime, source);
-  }
-
-  @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createCurrent(source);
+    super(runtime);
   }
 
   @Override
   public T search(T input) {
-    return source() == null ? input : super.search(input);
-  }
-
-  @Override
-  public String toString() {
-    if (source() == null) {
-      return "Current()";
-    } else {
-      return super.toString();
-    }
+    return input;
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/ExpressionReferenceNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/ExpressionReferenceNode.java
@@ -7,18 +7,13 @@ public class ExpressionReferenceNode<T> extends Node<T> {
   private final Expression<T> expression;
 
   public ExpressionReferenceNode(Adapter<T> runtime, Expression<T> expression) {
-    super(runtime, runtime.nodeFactory().createCurrent());
+    super(runtime);
     this.expression = expression;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    return expression().search(currentValue);
+  public T search(T input) {
+    return expression().search(input);
   }
 
   protected Expression<T> expression() {

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/FlattenArrayNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/FlattenArrayNode.java
@@ -7,19 +7,14 @@ import io.burt.jmespath.Adapter;
 import io.burt.jmespath.JmesPathType;
 
 public class FlattenArrayNode<T> extends Node<T> {
-  public FlattenArrayNode(Adapter<T> runtime, Node<T> source) {
-    super(runtime, source);
+  public FlattenArrayNode(Adapter<T> runtime) {
+    super(runtime);
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createFlattenArray(source);
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.ARRAY) {
-      List<T> elements = runtime.toList(currentValue);
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.ARRAY) {
+      List<T> elements = runtime.toList(input);
       List<T> flattened = new LinkedList<>();
       for (T element : elements) {
         if (runtime.typeOf(element) == JmesPathType.ARRAY) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/FlattenObjectNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/FlattenObjectNode.java
@@ -4,19 +4,14 @@ import io.burt.jmespath.Adapter;
 import io.burt.jmespath.JmesPathType;
 
 public class FlattenObjectNode<T> extends Node<T> {
-  public FlattenObjectNode(Adapter<T> runtime, Node<T> source) {
-    super(runtime, source);
+  public FlattenObjectNode(Adapter<T> runtime) {
+    super(runtime);
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createFlattenObject(source);
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.OBJECT) {
-      return runtime.createArray(runtime.toList(currentValue));
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.OBJECT) {
+      return runtime.createArray(runtime.toList(input));
     } else {
       return runtime.createNull();
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/FunctionCallNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/FunctionCallNode.java
@@ -13,25 +13,20 @@ public class FunctionCallNode<T> extends Node<T> {
   private final Function implementation;
   private final List<Expression<T>> args;
 
-  public FunctionCallNode(Adapter<T> runtime, Function implementation, List<? extends Expression<T>> args, Node<T> source) {
-    super(runtime, source);
+  public FunctionCallNode(Adapter<T> runtime, Function implementation, List<? extends Expression<T>> args) {
+    super(runtime);
     this.implementation = implementation;
     this.args = new ArrayList<>(args);
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createFunctionCall(implementation, args, source);
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
+  public T search(T input) {
     List<FunctionArgument<T>> arguments = new ArrayList<>(args.size());
     for (Expression<T> arg : args()) {
       if (arg instanceof ExpressionReferenceNode) {
         arguments.add(FunctionArgument.of(arg));
       } else {
-        arguments.add(FunctionArgument.of(arg.search(currentValue)));
+        arguments.add(FunctionArgument.of(arg.search(input)));
       }
     }
     return implementation.call(runtime, arguments);

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/IndexNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/IndexNode.java
@@ -8,20 +8,15 @@ import io.burt.jmespath.JmesPathType;
 public class IndexNode<T> extends Node<T> {
   private final int index;
 
-  public IndexNode(Adapter<T> runtime, int index, Node<T> source) {
-    super(runtime, source);
+  public IndexNode(Adapter<T> runtime, int index) {
+    super(runtime);
     this.index = index;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createIndex(index, source);
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.ARRAY) {
-      List<T> elements = runtime.toList(currentValue);
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.ARRAY) {
+      List<T> elements = runtime.toList(input);
       int i = index();
       if (i < 0) {
         i = elements.size() + i;

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/JsonLiteralNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/JsonLiteralNode.java
@@ -13,11 +13,6 @@ public class JsonLiteralNode<T> extends Node<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
   public T search(T input) {
     return tree();
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/NegateNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/NegateNode.java
@@ -1,29 +1,29 @@
 package io.burt.jmespath.node;
 
 import io.burt.jmespath.Adapter;
+import io.burt.jmespath.Expression;
 
 public class NegateNode<T> extends Node<T> {
-  public NegateNode(Adapter<T> runtime, Node<T> source) {
-    super(runtime, source);
+  private final Expression<T> negated;
+
+  public NegateNode(Adapter<T> runtime, Expression<T> negated) {
+    super(runtime);
+    this.negated = negated;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createNegate(source);
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    return runtime.createBoolean(!runtime.isTruthy(currentValue));
+  public T search(T input) {
+    return runtime.createBoolean(!runtime.isTruthy(negated.search(input)));
   }
 
   @Override
   protected boolean internalEquals(Object o) {
-    return true;
+    NegateNode<?> other = (NegateNode<?>)o;
+    return negated.equals(other.negated);
   }
 
   @Override
   protected int internalHashCode() {
-    return 19;
+    return 17 + 31 * negated.hashCode();
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/Node.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/Node.java
@@ -5,31 +5,13 @@ import io.burt.jmespath.Expression;
 
 public abstract class Node<T> implements Expression<T> {
   protected final Adapter<T> runtime;
-  private final Node<T> source;
 
   public Node(Adapter<T> runtime) {
-    this(runtime, runtime.nodeFactory().createCurrent());
-  }
-
-  public Node(Adapter<T> runtime, Node<T> source) {
     this.runtime = runtime;
-    this.source = source;
   }
-
-  public abstract Node<T> copyWithSource(Node<T> source);
 
   @Override
-  public T search(T input) {
-    return searchWithCurrentValue(source().search(input));
-  }
-
-  protected T searchWithCurrentValue(T currentValue) {
-    return currentValue;
-  }
-
-  public Node<T> source() {
-    return source;
-  }
+  public abstract T search(T input);
 
   @Override
   public String toString() {
@@ -41,11 +23,7 @@ public abstract class Node<T> implements Expression<T> {
     str.append('(');
     if (extraArgs != null) {
       str.append(extraArgs);
-      if (extraArgs.length() > 0 && !extraArgs.endsWith(", ")) {
-        str.append(", ");
-      }
     }
-    str.append(source());
     str.append(')');
     return str.toString();
   }
@@ -62,18 +40,14 @@ public abstract class Node<T> implements Expression<T> {
     if (!getClass().isInstance(o)) {
       return false;
     }
-    Node<?> other = (Node<?>) o;
-    return internalEquals(o) && (source() == other.source() || (source() != null && other.source() != null && source().equals(other.source())));
+    return internalEquals(o);
   }
 
   protected abstract boolean internalEquals(Object o);
 
   @Override
   public int hashCode() {
-    int h = 1;
-    h = h * 31 + internalHashCode();
-    h = h * 31 + (source() == null ? 0 : source().hashCode());
-    return h;
+    return internalHashCode();
   }
 
   protected abstract int internalHashCode();

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/NodeFactory.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/NodeFactory.java
@@ -11,21 +11,19 @@ import io.burt.jmespath.function.Function;
 public interface NodeFactory<T> {
   public Node<T> createCurrent();
 
-  public Node<T> createCurrent(Node<T> source);
+  public Node<T> createProperty(String name);
 
-  public Node<T> createProperty(String name, Node<T> source);
+  public Node<T> createIndex(int index);
 
-  public Node<T> createIndex(int index, Node<T> source);
+  public Node<T> createSlice(Integer start, Integer stop, Integer step);
 
-  public Node<T> createSlice(Integer start, Integer stop, Integer step, Node<T> source);
+  public Node<T> createProjection(Expression<T> expression);
 
-  public Node<T> createProjection(Expression<T> expression, Node<T> source);
+  public Node<T> createFlattenArray();
 
-  public Node<T> createFlattenArray(Node<T> source);
+  public Node<T> createFlattenObject();
 
-  public Node<T> createFlattenObject(Node<T> source);
-
-  public Node<T> createSelection(Expression<T> test, Node<T> source);
+  public Node<T> createSelection(Expression<T> test);
 
   public Node<T> createComparison(Operator operator, Expression<T> left, Expression<T> right);
 
@@ -33,19 +31,21 @@ public interface NodeFactory<T> {
 
   public Node<T> createAnd(Expression<T> left, Expression<T> right);
 
-  public Node<T> createFunctionCall(String functionName, List<? extends Expression<T>> args, Node<T> source);
+  public Node<T> createFunctionCall(String functionName, List<? extends Expression<T>> args);
 
-  public Node<T> createFunctionCall(Function function, List<? extends Expression<T>> args, Node<T> source);
+  public Node<T> createFunctionCall(Function function, List<? extends Expression<T>> args);
 
   public Node<T> createExpressionReference(Expression<T> expression);
 
   public Node<T> createString(String str);
 
-  public Node<T> createNegate(Node<T> source);
+  public Node<T> createNegate(Expression<T> negated);
 
-  public Node<T> createCreateObject(List<CreateObjectNode.Entry<T>> entries, Node<T> source);
+  public Node<T> createCreateObject(List<CreateObjectNode.Entry<T>> entries);
 
-  public Node<T> createCreateArray(List<? extends Expression<T>> entries, Node<T> source);
+  public Node<T> createCreateArray(List<? extends Expression<T>> entries);
 
   public Node<T> createJsonLiteral(String json);
+
+  public Node<T> createSequence(List<Node<T>> nodes);
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/OperatorNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/OperatorNode.java
@@ -16,9 +16,6 @@ public abstract class OperatorNode<T> extends Node<T> {
     this.operands = Arrays.asList(operands);
   }
 
-  @Override
-  public abstract Node<T> copyWithSource(Node<T> source);
-
   protected List<Expression<T>> operands() {
     return operands;
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/OrNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/OrNode.java
@@ -9,17 +9,12 @@ public class OrNode<T> extends OperatorNode<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
-  protected T searchWithCurrentValue(T currentValue) {
-    T leftResult = operand(0).search(currentValue);
+  public T search(T input) {
+    T leftResult = operand(0).search(input);
     if (runtime.isTruthy(leftResult)) {
       return leftResult;
     } else {
-      return operand(1).search(currentValue);
+      return operand(1).search(input);
     }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/ProjectionNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/ProjectionNode.java
@@ -10,23 +10,18 @@ import io.burt.jmespath.JmesPathType;
 public class ProjectionNode<T> extends Node<T> {
   private final Expression<T> projection;
 
-  public ProjectionNode(Adapter<T> runtime, Expression<T> projection, Node<T> source) {
-    super(runtime, source);
+  public ProjectionNode(Adapter<T> runtime, Expression<T> projection) {
+    super(runtime);
     this.projection = projection;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createProjection(projection, source);
-  }
-
-  @Override
-  public T searchWithCurrentValue(T currentValue) {
-    if (runtime.typeOf(currentValue) == JmesPathType.ARRAY) {
-      List<T> inputs = runtime.toList(currentValue);
-      List<T> results = new ArrayList<>(inputs.size());
-      for (T input : inputs) {
-        T result = projection.search(input);
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.ARRAY) {
+      List<T> inputList = runtime.toList(input);
+      List<T> results = new ArrayList<>(inputList.size());
+      for (T inputItem : inputList) {
+        T result = projection.search(inputItem);
         JmesPathType type = runtime.typeOf(result);
         if (type != JmesPathType.NULL) {
           results.add(result);

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/PropertyNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/PropertyNode.java
@@ -5,19 +5,14 @@ import io.burt.jmespath.Adapter;
 public class PropertyNode<T> extends Node<T> {
   private final String propertyName;
 
-  public PropertyNode(Adapter<T> runtime, String propertyName, Node<T> source) {
-    super(runtime, source);
+  public PropertyNode(Adapter<T> runtime, String propertyName) {
+    super(runtime);
     this.propertyName = propertyName;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createProperty(propertyName, source);
-  }
-
-  @Override
-  public T searchWithCurrentValue(T currentValue) {
-    return runtime.getProperty(currentValue, propertyName());
+  public T search(T input) {
+    return runtime.getProperty(input, propertyName());
   }
 
   protected String propertyName() {

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/SelectionNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/SelectionNode.java
@@ -10,21 +10,16 @@ import io.burt.jmespath.JmesPathType;
 public class SelectionNode<T> extends Node<T> {
   private final Expression<T> test;
 
-  public SelectionNode(Adapter<T> runtime, Expression<T> test, Node<T> source) {
-    super(runtime, source);
+  public SelectionNode(Adapter<T> runtime, Expression<T> test) {
+    super(runtime);
     this.test = test;
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createSelection(test, source);
-  }
-
-  @Override
-  public T searchWithCurrentValue(T projectionElement) {
-    if (runtime.typeOf(projectionElement) == JmesPathType.ARRAY) {
+  public T search(T input) {
+    if (runtime.typeOf(input) == JmesPathType.ARRAY) {
       List<T> selectedElements = new LinkedList<>();
-      for (T element : runtime.toList(projectionElement)) {
+      for (T element : runtime.toList(input)) {
         T testResult = test().search(element);
         if (runtime.isTruthy(testResult)) {
           selectedElements.add(element);

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/SequenceNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/SequenceNode.java
@@ -1,0 +1,51 @@
+package io.burt.jmespath.node;
+
+import java.util.Iterator;
+import java.util.List;
+
+import io.burt.jmespath.Adapter;
+
+public class SequenceNode<T> extends Node<T> {
+  private final List<Node<T>> nodes;
+
+  public SequenceNode(Adapter<T> runtime, List<Node<T>> nodes) {
+    super(runtime);
+    this.nodes = nodes;
+  }
+
+  @Override
+  protected String internalToString() {
+    if (nodes.isEmpty()) {
+      return null;
+    } else {
+      StringBuilder buffer = new StringBuilder();
+      Iterator<Node<T>> iterator = nodes.iterator();
+      buffer.append(iterator.next());
+      while (iterator.hasNext()) {
+        buffer.append(", ");
+        buffer.append(iterator.next());
+      }
+      return buffer.toString();
+    }
+  }
+
+  @Override
+  protected boolean internalEquals(Object o) {
+    SequenceNode<?> other = (SequenceNode<?>) o;
+    return nodes.equals(other.nodes);
+  }
+
+  @Override
+  protected int internalHashCode() {
+    return nodes.hashCode();
+  }
+
+  @Override
+  public T search(T input) {
+    T value = input;
+    for (Node<T> node : nodes) {
+      value = node.search(value);
+    }
+    return value;
+  }
+}

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/SliceNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/SliceNode.java
@@ -15,8 +15,8 @@ public class SliceNode<T> extends Node<T> {
   private final int limit;
   private final int rounding;
 
-  public SliceNode(Adapter<T> runtime, Integer start, Integer stop, Integer step, Node<T> source) {
-    super(runtime, source);
+  public SliceNode(Adapter<T> runtime, Integer start, Integer stop, Integer step) {
+    super(runtime);
     this.absoluteStart = (start != null);
     this.absoluteStop = (stop != null);
     this.absoluteStep = (step != null);
@@ -28,18 +28,8 @@ public class SliceNode<T> extends Node<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return runtime.nodeFactory().createSlice(
-      absoluteStart ? start : null,
-      absoluteStop ? stop : null,
-      absoluteStep ? step : null,
-      source
-    );
-  }
-
-  @Override
-  public T searchWithCurrentValue(T projectionElement) {
-    List<T> elements = runtime.toList(projectionElement);
+  public T search(T input) {
+    List<T> elements = runtime.toList(input);
     int begin = (start < 0) ? Math.max(elements.size() + start, 0) : Math.min(start, elements.size() + limit);
     int end = (stop < 0) ? Math.max(elements.size() + stop, limit) : Math.min(stop, elements.size());
     int steps = Math.max(0, (end - begin + rounding) / step);

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/StandardNodeFactory.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/StandardNodeFactory.java
@@ -22,43 +22,43 @@ public class StandardNodeFactory<T> implements NodeFactory<T> {
   }
 
   @Override
-  public Node<T> createCurrent(Node<T> source) {
-    return new CurrentNode<>(runtime, source);
+  public Node<T> createSequence(List<Node<T>> nodes) {
+    return new SequenceNode<>(runtime, nodes);
   }
 
   @Override
-  public Node<T> createProperty(String name, Node<T> source) {
-    return new PropertyNode<>(runtime, name, source);
+  public Node<T> createProperty(String name) {
+    return new PropertyNode<>(runtime, name);
   }
 
   @Override
-  public Node<T> createIndex(int index, Node<T> source) {
-    return new IndexNode<>(runtime, index, source);
+  public Node<T> createIndex(int index) {
+    return new IndexNode<>(runtime, index);
   }
 
   @Override
-  public Node<T> createSlice(Integer start, Integer stop, Integer step, Node<T> source) {
-    return new SliceNode<>(runtime, start, stop, step, source);
+  public Node<T> createSlice(Integer start, Integer stop, Integer step) {
+    return new SliceNode<>(runtime, start, stop, step);
   }
 
   @Override
-  public Node<T> createProjection(Expression<T> expression, Node<T> source) {
-    return new ProjectionNode<>(runtime, expression, source);
+  public Node<T> createProjection(Expression<T> expression) {
+    return new ProjectionNode<>(runtime, expression);
   }
 
   @Override
-  public Node<T> createFlattenArray(Node<T> source) {
-    return new FlattenArrayNode<>(runtime, source);
+  public Node<T> createFlattenArray() {
+    return new FlattenArrayNode<>(runtime);
   }
 
   @Override
-  public Node<T> createFlattenObject(Node<T> source) {
-    return new FlattenObjectNode<>(runtime, source);
+  public Node<T> createFlattenObject() {
+    return new FlattenObjectNode<>(runtime);
   }
 
   @Override
-  public Node<T> createSelection(Expression<T> test, Node<T> source) {
-    return new SelectionNode<>(runtime, test, source);
+  public Node<T> createSelection(Expression<T> test) {
+    return new SelectionNode<>(runtime, test);
   }
 
   @Override
@@ -77,13 +77,13 @@ public class StandardNodeFactory<T> implements NodeFactory<T> {
   }
 
   @Override
-  public Node<T> createFunctionCall(String functionName, List<? extends Expression<T>> args, Node<T> source) {
-    return new FunctionCallNode<>(runtime, runtime.functionRegistry().getFunction(functionName), args, source);
+  public Node<T> createFunctionCall(String functionName, List<? extends Expression<T>> args) {
+    return new FunctionCallNode<>(runtime, runtime.functionRegistry().getFunction(functionName), args);
   }
 
   @Override
-  public Node<T> createFunctionCall(Function function, List<? extends Expression<T>> args, Node<T> source) {
-    return new FunctionCallNode<>(runtime, function, args, source);
+  public Node<T> createFunctionCall(Function function, List<? extends Expression<T>> args) {
+    return new FunctionCallNode<>(runtime, function, args);
   }
 
   @Override
@@ -97,18 +97,18 @@ public class StandardNodeFactory<T> implements NodeFactory<T> {
   }
 
   @Override
-  public Node<T> createNegate(Node<T> source) {
-    return new NegateNode<>(runtime, source);
+  public Node<T> createNegate(Expression<T> negated) {
+    return new NegateNode<>(runtime, negated);
   }
 
   @Override
-  public Node<T> createCreateObject(List<CreateObjectNode.Entry<T>> entries, Node<T> source) {
-    return new CreateObjectNode<>(runtime, entries, source);
+  public Node<T> createCreateObject(List<CreateObjectNode.Entry<T>> entries) {
+    return new CreateObjectNode<>(runtime, entries);
   }
 
   @Override
-  public Node<T> createCreateArray(List<? extends Expression<T>> entries, Node<T> source) {
-    return new CreateArrayNode<>(runtime, entries, source);
+  public Node<T> createCreateArray(List<? extends Expression<T>> entries) {
+    return new CreateArrayNode<>(runtime, entries);
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/StringNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/StringNode.java
@@ -11,11 +11,6 @@ public class StringNode<T> extends Node<T> {
   }
 
   @Override
-  public Node<T> copyWithSource(Node<T> source) {
-    return this;
-  }
-
-  @Override
   public T search(T input) {
     return runtime.createString(string());
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
@@ -1,9 +1,8 @@
 package io.burt.jmespath.parser;
 
-import java.util.Deque;
 import java.util.List;
-import java.util.LinkedList;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -16,8 +15,6 @@ import io.burt.jmespath.util.AntlrHelper;
 import io.burt.jmespath.node.NodeFactory;
 import io.burt.jmespath.node.Node;
 import io.burt.jmespath.node.CreateObjectNode.Entry;
-import io.burt.jmespath.node.ProjectionNode;
-import io.burt.jmespath.node.CurrentNode;
 import io.burt.jmespath.node.Operator;
 
 public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
@@ -44,53 +41,12 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     '`', '`'
   );
 
-  private static class StartProjectionNode<T> extends Node<T> {
-    public StartProjectionNode(Adapter<T> runtime, Node<T> source) {
-      super(runtime, source);
-    }
-
-    @Override
-    public Node<T> copyWithSource(Node<T> source) {
-      return new StartProjectionNode<>(runtime, source);
-    }
-
-    @Override
-    protected boolean internalEquals(Object o) {
-      return true;
-    }
-
-    @Override
-    protected int internalHashCode() {
-      return 31;
-    }
-  }
-
-  private static class StopProjectionsNode<T> extends Node<T> {
-    public StopProjectionsNode(Adapter<T> runtime, Node<T> source) {
-      super(runtime, source);
-    }
-
-    @Override
-    public Node<T> copyWithSource(Node<T> source) {
-      return new StopProjectionsNode<>(runtime, source);
-    }
-
-    @Override
-    protected boolean internalEquals(Object o) {
-      return true;
-    }
-
-    @Override
-    protected int internalHashCode() {
-      return 31;
-    }
-  }
-
   private final ParseTree tree;
-  private final Deque<Node<T>> currentSource;
   private final Adapter<T> runtime;
   private final NodeFactory<T> nodeFactory;
   private final ParseErrorAccumulator errors;
+
+  private Node<T> chainedNode;
 
   public static <U> Expression<U> fromString(Adapter<U> runtime, String rawExpression) {
     ParseErrorAccumulator errors = new ParseErrorAccumulator();
@@ -112,73 +68,10 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     this.nodeFactory = runtime.nodeFactory();
     this.tree = tree;
     this.errors = errors;
-    this.currentSource = new LinkedList<>();
   }
 
   public Expression<T> expression() {
-    return rewriteProjections(visit(tree));
-  }
-
-  private Node<T> createCurrent() {
-    return nodeFactory.createCurrent();
-  }
-
-  private Node<T> createProjection(Expression<T> expression, Node<T> source) {
-    return nodeFactory.createProjection(expression, source);
-  }
-
-  private Node<T> startProjection(Node<T> source) {
-    return new StartProjectionNode<>(runtime, source);
-  }
-
-  private Node<T> stopProjections(Node<T> source) {
-    return new StopProjectionsNode<>(runtime, source);
-  }
-
-  private Node<T> rewriteProjections(Node<T> node) {
-    return removeStopProjections(rewriteProjections(node, node));
-  }
-
-  private Node<T> rewriteProjections(Node<T> node, Node<T> root) {
-    Node<T> source = node.source();
-    if (source == null) {
-      return node;
-    } else if (node instanceof StartProjectionNode) {
-      Node<T> rearrangedSource = rewriteProjections(source, source);
-      return createProjection(createCurrent(), rearrangedSource);
-    } else if (source instanceof StopProjectionsNode) {
-      Node<T> rearrangedSource = rewriteProjections(source, source);
-      return node.copyWithSource(rearrangedSource);
-    } else if (source instanceof StartProjectionNode) {
-      Node<T> projectionExpression = removeStopProjections(reSource(root, source, createCurrent()));
-      Node<T> projection = createProjection(projectionExpression, source.source());
-      return rewriteProjections(projection, projection);
-    } else {
-      Node<T> rearrangedSource = rewriteProjections(source, root);
-      if (rearrangedSource instanceof ProjectionNode) {
-        return rearrangedSource;
-      } else {
-        return node.copyWithSource(rearrangedSource);
-      }
-    }
-  }
-
-  private Node<T> removeStopProjections(Node<T> node) {
-    if (node instanceof StopProjectionsNode) {
-      return removeStopProjections(node.source());
-    } else if (node.source() == null) {
-      return node;
-    } else {
-      return node.copyWithSource(removeStopProjections(node.source()));
-    }
-  }
-
-  private Node<T> reSource(Node<T> root, Node<T> node, Node<T> replacement) {
-    Node<T> newSource = replacement;
-    if (root.source() != node) {
-      newSource = reSource(root.source(), node, replacement);
-    }
-    return root.copyWithSource(newSource);
+    return visit(tree);
   }
 
   private String identifierToString(JmesPathParser.IdentifierContext ctx) {
@@ -207,20 +100,32 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     return -1;
   }
 
+  private Node<T> createProjectionIfChained(Node<T> node) {
+    if (chainedNode != null) {
+      node = nodeFactory.createSequence(Arrays.asList(node, nodeFactory.createProjection(chainedNode)));
+      chainedNode = null;
+    }
+    return node;
+  }
+
+  private Node<T> createSequenceIfChained(Node<T> node) {
+    if (chainedNode != null) {
+      node = nodeFactory.createSequence(Arrays.asList(node, chainedNode));
+      chainedNode = null;
+    }
+    return node;
+  }
+
   @Override
   public Node<T> visitJmesPathExpression(JmesPathParser.JmesPathExpressionContext ctx) {
-    currentSource.push(createCurrent());
-    Node<T> result = visit(ctx.expression());
-    currentSource.pop();
-    return result;
+    return createSequenceIfChained(visit(ctx.expression()));
   }
 
   @Override
   public Node<T> visitPipeExpression(JmesPathParser.PipeExpressionContext ctx) {
-    currentSource.push(stopProjections(visit(ctx.expression(0))));
-    Node<T> result = visit(ctx.expression(1));
-    currentSource.pop();
-    return result;
+    Node<T> right = createSequenceIfChained(visit(ctx.expression(1)));
+    Node<T> left = createSequenceIfChained(visit(ctx.expression(0)));
+    return nodeFactory.createSequence(Arrays.asList(left, right));
   }
 
   @Override
@@ -230,7 +135,7 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
 
   @Override
   public Node<T> visitNotExpression(JmesPathParser.NotExpressionContext ctx) {
-    return nodeFactory.createNegate(visit(ctx.expression()));
+    return nodeFactory.createNegate(createSequenceIfChained(visit(ctx.expression())));
   }
 
   @Override
@@ -243,41 +148,53 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
   @Override
   public Node<T> visitComparisonExpression(JmesPathParser.ComparisonExpressionContext ctx) {
     Operator operator = Operator.fromString(ctx.COMPARATOR().getText());
-    Node<T> left = rewriteProjections(visit(ctx.expression(0)));
-    Node<T> right = rewriteProjections(visit(ctx.expression(1)));
-    return nodeFactory.createComparison(operator, left, right);
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
+    Node<T> right = createSequenceIfChained(visit(ctx.expression(1)));
+    Node<T> left = createSequenceIfChained(visit(ctx.expression(0)));
+    chainedNode = oldChainedNode;
+    return createSequenceIfChained(nodeFactory.createComparison(operator, left, right));
   }
 
   @Override
   public Node<T> visitParenExpression(JmesPathParser.ParenExpressionContext ctx) {
-    return visit(ctx.expression());
+    return createSequenceIfChained(visit(ctx.expression()));
   }
 
   @Override
   public Node<T> visitBracketExpression(JmesPathParser.BracketExpressionContext ctx) {
-    return visit(ctx.bracketSpecifier());
-  }
-
-  @Override
-  public Node<T> visitOrExpression(JmesPathParser.OrExpressionContext ctx) {
-    Node<T> left = rewriteProjections(visit(ctx.expression(0)));
-    Node<T> right = rewriteProjections(visit(ctx.expression(1)));
-    return nodeFactory.createOr(left, right);
-  }
-
-  @Override
-  public Node<T> visitChainExpression(JmesPathParser.ChainExpressionContext ctx) {
-    currentSource.push(visit(ctx.expression()));
-    Node<T> result = visit(ctx.chainedExpression());
-    currentSource.pop();
+    Node<T> result = visit(ctx.bracketSpecifier());
+    if (result == null) {
+      result = chainedNode;
+      chainedNode = null;
+    }
     return result;
   }
 
   @Override
+  public Node<T> visitOrExpression(JmesPathParser.OrExpressionContext ctx) {
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
+    Node<T> left = createSequenceIfChained(visit(ctx.expression(0)));
+    Node<T> right = createSequenceIfChained(visit(ctx.expression(1)));
+    chainedNode = oldChainedNode;
+    return createSequenceIfChained(nodeFactory.createOr(left, right));
+  }
+
+  @Override
+  public Node<T> visitChainExpression(JmesPathParser.ChainExpressionContext ctx) {
+    chainedNode = visit(ctx.chainedExpression());
+    return createSequenceIfChained(visit(ctx.expression()));
+  }
+
+  @Override
   public Node<T> visitAndExpression(JmesPathParser.AndExpressionContext ctx) {
-    Node<T> left = rewriteProjections(visit(ctx.expression(0)));
-    Node<T> right = rewriteProjections(visit(ctx.expression(1)));
-    return nodeFactory.createAnd(left, right);
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
+    Node<T> left = createSequenceIfChained(visit(ctx.expression(0)));
+    Node<T> right = createSequenceIfChained(visit(ctx.expression(1)));
+    chainedNode = oldChainedNode;
+    return createSequenceIfChained(nodeFactory.createAnd(left, right));
   }
 
   @Override
@@ -287,53 +204,64 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
 
   @Override
   public Node<T> visitBracketedExpression(JmesPathParser.BracketedExpressionContext ctx) {
-    currentSource.push(visit(ctx.expression()));
-    Node<T> result = visit(ctx.bracketSpecifier());
-    currentSource.pop();
-    return result;
+    Node<T> bracket = visit(ctx.bracketSpecifier());
+    if (bracket == null) {
+      return createSequenceIfChained(visit(ctx.expression()));
+    } else {
+      Node<T> expression = visit(ctx.expression());
+      chainedNode = bracket;
+      return createSequenceIfChained(expression);
+    }
   }
+  
+  
 
   @Override
   public Node<T> visitWildcard(JmesPathParser.WildcardContext ctx) {
-    return startProjection(nodeFactory.createFlattenObject(currentSource.peek()));
+    return createProjectionIfChained(nodeFactory.createFlattenObject());
   }
 
   @Override
   public Node<T> visitMultiSelectList(JmesPathParser.MultiSelectListContext ctx) {
-    currentSource.push(createCurrent());
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
     int n = ctx.expression().size();
     List<Expression<T>> entries = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
-      entries.add(rewriteProjections(visit(ctx.expression(i))));
+      entries.add(createSequenceIfChained(visit(ctx.expression(i))));
     }
-    currentSource.pop();
-    return nodeFactory.createCreateArray(entries, currentSource.peek());
+    chainedNode = oldChainedNode;
+    return createSequenceIfChained(nodeFactory.createCreateArray(entries));
   }
 
   @Override
   public Node<T> visitMultiSelectHash(JmesPathParser.MultiSelectHashContext ctx) {
-    currentSource.push(createCurrent());
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
     int n = ctx.keyvalExpr().size();
     List<Entry<T>> entries = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
       JmesPathParser.KeyvalExprContext kvCtx = ctx.keyvalExpr(i);
       String key = identifierToString(kvCtx.identifier());
-      Node<T> value = rewriteProjections(visit(kvCtx.expression()));
+      Node<T> value = createSequenceIfChained(visit(kvCtx.expression()));
       entries.add(new Entry<>(key, value));
     }
-    currentSource.pop();
-    return nodeFactory.createCreateObject(entries, currentSource.peek());
+    chainedNode = oldChainedNode;
+    return createSequenceIfChained(nodeFactory.createCreateObject(entries));
   }
 
   @Override
   public Node<T> visitBracketIndex(JmesPathParser.BracketIndexContext ctx) {
     int index = Integer.parseInt(ctx.SIGNED_INT().getText());
-    return nodeFactory.createIndex(index, currentSource.peek());
+    chainedNode = createSequenceIfChained(nodeFactory.createIndex(index));
+    return null;
   }
 
   @Override
   public Node<T> visitBracketStar(JmesPathParser.BracketStarContext ctx) {
-    return startProjection(currentSource.peek());
+    Node<T> projection = (chainedNode == null) ? nodeFactory.createCurrent() : chainedNode;
+    chainedNode = nodeFactory.createProjection(projection);
+    return null;
   }
 
   @Override
@@ -351,52 +279,58 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     if (sliceCtx.step != null) {
       step = Integer.parseInt(sliceCtx.step.getText());
     }
-    return startProjection(nodeFactory.createSlice(start, stop, step, currentSource.peek()));
+    chainedNode = createProjectionIfChained(nodeFactory.createSlice(start, stop, step));
+    return null;
   }
 
   @Override
   public Node<T> visitBracketFlatten(JmesPathParser.BracketFlattenContext ctx) {
-    return startProjection(nodeFactory.createFlattenArray(stopProjections(currentSource.peek())));
+    return createProjectionIfChained(nodeFactory.createFlattenArray());
   }
 
   @Override
   public Node<T> visitSelect(JmesPathParser.SelectContext ctx) {
-    currentSource.push(createCurrent());
-    Node<T> test = rewriteProjections(visit(ctx.expression()));
-    currentSource.pop();
-    return startProjection(nodeFactory.createSelection(test, currentSource.peek()));
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
+    Node<T> test = createSequenceIfChained(visit(ctx.expression()));
+    chainedNode = oldChainedNode;
+    chainedNode = createProjectionIfChained(nodeFactory.createSelection(test));
+    return null;
   }
 
   @Override
   public Node<T> visitFunctionExpression(JmesPathParser.FunctionExpressionContext ctx) {
-    currentSource.push(createCurrent());
+    Node<T> oldChainedNode = chainedNode;
+    chainedNode = null;
     String name = ctx.NAME().getText();
     int n = ctx.functionArg().size();
     List<Expression<T>> args = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
-      args.add(rewriteProjections(visit(ctx.functionArg(i))));
+      args.add(visit(ctx.functionArg(i)));
     }
-    currentSource.pop();
+    chainedNode = oldChainedNode;
     Function implementation = runtime.functionRegistry().getFunction(name);
     if (implementation == null) {
       Token token = ctx.NAME().getSymbol();
       errors.parseError(String.format("unknown function \"%s\"", name), token.getLine(), token.getStartIndex());
     }
-    return nodeFactory.createFunctionCall(implementation, args, currentSource.peek());
+    return createSequenceIfChained(nodeFactory.createFunctionCall(implementation, args));
   }
 
   @Override
   public Node<T> visitCurrentNode(JmesPathParser.CurrentNodeContext ctx) {
-    if (currentSource.peek() instanceof CurrentNode) {
-      return currentSource.peek();
+    if (chainedNode == null) {
+      return nodeFactory.createCurrent();
     } else {
-      return nodeFactory.createCurrent(currentSource.peek());
+      Node<T> result = chainedNode;
+      chainedNode = null;
+      return result;
     }
   }
 
   @Override
   public Node<T> visitExpressionType(JmesPathParser.ExpressionTypeContext ctx) {
-    Node<T> expression = rewriteProjections(visit(ctx.expression()));
+    Node<T> expression = createSequenceIfChained(visit(ctx.expression()));
     return nodeFactory.createExpressionReference(expression);
   }
 
@@ -421,6 +355,6 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
 
   @Override
   public Node<T> visitIdentifier(JmesPathParser.IdentifierContext ctx) {
-    return nodeFactory.createProperty(identifierToString(ctx), currentSource.peek());
+    return createSequenceIfChained(nodeFactory.createProperty(identifierToString(ctx)));
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
@@ -163,7 +163,7 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
 
   @Override
   public Node<T> visitParenExpression(JmesPathParser.ParenExpressionContext ctx) {
-    return createSequenceIfChained(visit(ctx.expression()));
+    return createSequenceIfChained(nonChainingVisit(ctx.expression()));
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
@@ -203,17 +203,11 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
 
   @Override
   public Node<T> visitBracketedExpression(JmesPathParser.BracketedExpressionContext ctx) {
-    Node<T> bracket = visit(ctx.bracketSpecifier());
-    if (bracket == null) {
-      return createSequenceIfChained(visit(ctx.expression()));
-    } else {
-      Node<T> expression = visit(ctx.expression());
-      chainedNode = bracket;
-      return createSequenceIfChained(expression);
-    }
+    Node<T> chainAfterExpression = visit(ctx.bracketSpecifier());
+    Node<T> expression = createSequenceIfChained(visit(ctx.expression()));
+    chainedNode = chainAfterExpression;
+    return createSequenceIfChained(expression);
   }
-  
-  
 
   @Override
   public Node<T> visitWildcard(JmesPathParser.WildcardContext ctx) {

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
@@ -74,7 +74,7 @@ public abstract class JmesPathComplianceTest<T> {
         U result = compiledExpression.search(input);
         if (expectedError == null) {
           assertTrue(
-            String.format("Expected <%s> to be <%s>", result, expectedResult),
+            String.format("Expected <%s> to be <%s>, expression <%s> compiled expression <%s>", result, expectedResult, expression, compiledExpression),
             runtime.compare(expectedResult, result) == 0
           );
         } else if ("syntax".equals(expectedError)) {

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -46,7 +46,8 @@ public abstract class JmesPathRuntimeTest<T> {
   }
 
   protected T search(String query, T input) {
-    return runtime().compile(query).search(input);
+    Expression<T> expression = runtime().compile(query);
+    return expression.search(input);
   }
 
   protected T parse(String json) {

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -2,7 +2,6 @@ package io.burt.jmespath;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.BaseMatcher;

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
@@ -10,7 +10,6 @@ import io.burt.jmespath.Adapter;
 import io.burt.jmespath.JmesPathType;
 import io.burt.jmespath.node.ExpressionReferenceNode;
 import io.burt.jmespath.node.PropertyNode;
-import io.burt.jmespath.node.CurrentNode;
 import io.burt.jmespath.jcf.JcfRuntime;
 
 import static org.junit.Assert.assertThat;
@@ -23,7 +22,7 @@ public class FunctionTest {
 
   private final FunctionArgument<Object> expressionReference = FunctionArgument.of(
     new ExpressionReferenceNode<Object>(runtime,
-      new PropertyNode<Object>(runtime, "foo", new CurrentNode<Object>(runtime))
+      new PropertyNode<Object>(runtime, "foo")
     )
   );
 

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -3,6 +3,7 @@ package io.burt.jmespath.parser;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.burt.jmespath.Adapter;
@@ -282,9 +283,9 @@ public class ParserTest {
     assertThat(actual, is(expected));
   }
 
-  @Test
+  @Test(expected=ParseException.class)
+  @Ignore
   public void sliceWithZeroStepSize() {
-    // TODO: SHOULD FAIL?
     compile("[0:1:0]");
   }
 

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -4,30 +4,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
 import io.burt.jmespath.jcf.JcfRuntime;
-import io.burt.jmespath.node.AndNode;
-import io.burt.jmespath.node.ComparisonNode;
-import io.burt.jmespath.node.CreateArrayNode;
 import io.burt.jmespath.node.CreateObjectNode;
-import io.burt.jmespath.node.CurrentNode;
-import io.burt.jmespath.node.ExpressionReferenceNode;
-import io.burt.jmespath.node.FlattenArrayNode;
-import io.burt.jmespath.node.FlattenObjectNode;
-import io.burt.jmespath.node.ProjectionNode;
-import io.burt.jmespath.node.FunctionCallNode;
-import io.burt.jmespath.node.IndexNode;
 import io.burt.jmespath.node.Node;
-import io.burt.jmespath.node.JsonLiteralNode;
-import io.burt.jmespath.node.NegateNode;
-import io.burt.jmespath.node.OrNode;
-import io.burt.jmespath.node.PropertyNode;
-import io.burt.jmespath.node.SelectionNode;
-import io.burt.jmespath.node.SliceNode;
-import io.burt.jmespath.node.StringNode;
 import io.burt.jmespath.node.Operator;
 
 import static org.junit.Assert.assertThat;

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -1127,4 +1127,17 @@ public class ParserTest {
     Expression<Object> actual = compile("Records[?''] | !@");
     assertThat(actual, is(expected));
   }
+
+  @Test
+  public void chainedParenthesis() {
+    Expression<Object> expected = Sequence(
+      Sequence(
+        Property("foo"),
+        FlattenArray()
+      ),
+      Property("bar")
+    );
+    Expression<Object> actual = compile("(foo[]).bar");
+    assertThat(actual, is(expected));
+  }
 }


### PR DESCRIPTION
This was mainly implemented as a proof-of-concept, and especially the implementation of ExpressionParser is a bit not-so-nice.

Rewriting the parser tests really wasn't funny, and while I did most of them manually up front, I sometimes wrote `Sequence(x,Sequence(y,z))` instead of `Sequence(Sequence(x,y),z)`, so in the end a couple of expected results were essentially retrofitted to the output provided by the code. It seems to be passing all the compliance tests, though.

I tried to stay away from optimizing the structure, and while I originally intended to flatten the Sequence nodes to long chains instead of always having two children, I reverted to the somewhat simpler implementation first.

It turns out to be marginally less code in its current form.

@iconara, what do you think?