### PR TITLE
Compliant errors

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentTypeException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentTypeException.java
@@ -7,6 +7,6 @@ public class ArgumentTypeException extends FunctionCallException {
   }
 
   public ArgumentTypeException(String functionName, String expectedType, String actualType, Throwable cause) {
-    super(String.format("Wrong type of argument calling %s: expected %s but was %s", functionName, expectedType, actualType), cause);
+    super(String.format("Invalid argument type calling \"%s\": expected %s but was %s", functionName, expectedType, actualType), cause);
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArityException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArityException.java
@@ -12,11 +12,11 @@ public class ArityException extends FunctionCallException {
 
   private static String createMessage(String functionName, int minArity, int maxArity, int numArguments) {
     if (maxArity == minArity) {
-      return String.format("Wrong number of arguments calling %s: expected %d but was %d", functionName, minArity, numArguments);
+      return String.format("Invalid arity calling \"%s\": expected %d but was %d", functionName, minArity, numArguments);
     } else if (numArguments < minArity) {
-      return String.format("Wrong number of arguments calling %s: expected at least %d but was %d", functionName, minArity, numArguments);
+      return String.format("Invalid arity calling \"%s\": expected at least %d but was %d", functionName, minArity, numArguments);
     } else {
-      return String.format("Wrong number of arguments calling %s: expected at most %d but was %d", functionName, maxArity, numArguments);
+      return String.format("Invalid arity calling \"%s\": expected at most %d but was %d", functionName, maxArity, numArguments);
     }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
@@ -85,7 +85,7 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
   private void checkForUnescapedBackticks(Token token) {
     int unescapedBacktickIndex = indexOfUnescapedBacktick(token.getText());
     if (unescapedBacktickIndex > -1) {
-      errors.parseError("unexpected `", token.getLine(), token.getStartIndex() + unescapedBacktickIndex);
+      errors.parseError("syntax error unexpected `", token.getLine(), token.getStartIndex() + unescapedBacktickIndex);
     }
   }
 
@@ -255,7 +255,7 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
   public Node<T> visitBracketSlice(JmesPathParser.BracketSliceContext ctx) {
     Integer start = null;
     Integer stop = null;
-    Integer step = 1;
+    Integer step = null;
     JmesPathParser.SliceContext sliceCtx = ctx.slice();
     if (sliceCtx.start != null) {
       start = Integer.parseInt(sliceCtx.start.getText());
@@ -265,6 +265,9 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     }
     if (sliceCtx.step != null) {
       step = Integer.parseInt(sliceCtx.step.getText());
+      if (step == 0) {
+        errors.parseError(String.format("invalid value %d for step size", step), sliceCtx.step.getLine(), sliceCtx.step.getStartIndex());
+      }
     }
     chainedNode = createProjectionIfChained(nodeFactory.createSlice(start, stop, step));
     return null;

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseErrorAccumulator.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseErrorAccumulator.java
@@ -26,7 +26,7 @@ public class ParseErrorAccumulator extends BaseErrorListener implements Iterable
 
   @Override
   public void syntaxError(Recognizer<?,?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-    errors.add(new ParseError(msg, line, charPositionInLine));
+    errors.add(new ParseError(String.format("syntax error %s", msg), line, charPositionInLine));
   }
 
   public void parseError(String msg, int line, int charPositionInLine) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseException.java
@@ -9,7 +9,7 @@ public class ParseException extends JmesPathException implements Iterable<ParseE
   private final Iterable<ParseError> errors;
 
   public ParseException(String query, Iterable<ParseError> errors) {
-    super(String.format("Error while parsing \"%s\": %s", query, joinMessages(errors)));
+    super(String.format("Unable to compile expression \"%s\": %s", query, joinMessages(errors)));
     this.errors = errors;
   }
 

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
@@ -16,6 +16,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarEntry;
 
 import org.junit.runner.RunWith;
+import org.hamcrest.Matcher;
 
 import io.burt.jmespath.parser.ParseException;
 import io.burt.jmespath.function.ArgumentTypeException;
@@ -26,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.allOf;
 
 @RunWith(ComplianceRunner.class)
 public abstract class JmesPathComplianceTest<T> {
@@ -86,19 +87,13 @@ public abstract class JmesPathComplianceTest<T> {
       } catch (Exception e) {
         if (expectedError == null) {
           throw e;
-        } else if (expectedError.contains("-")) {
-          assertThat(
-            e.getMessage(),
-            anyOf(
-              containsString(expectedError),
-              containsString(expectedError.replaceAll("-", " "))
-            )
-          );
         } else {
-          assertThat(
-            e.getMessage(),
-            containsString(expectedError)
-          );
+          String[] pieces = expectedError.split("-");
+          Matcher<String> matcher = containsString(pieces[0]);
+          for (int i = 1; i < pieces.length; i++) {
+            matcher = allOf(matcher, containsString(pieces[i]));
+          }
+          assertThat(e.getMessage().toLowerCase(), matcher);
         }
       }
     }

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
@@ -168,7 +168,7 @@ public abstract class JmesPathComplianceTest<T> {
         T expectedResult = runtime().getProperty(caseDescription, "result");
         String expectedError = valueAsStringOrNull(caseDescription, "error");
         String benchmark = valueAsStringOrNull(caseDescription, "benchmark");
-        if (runtime().typeOf(expectedResult) != JmesPathType.NULL) {
+        if (runtime().typeOf(expectedResult) != JmesPathType.NULL || expectedError != null) {
           tests.add(new ComplianceTest<T>(runtime(), featureName, expression, input, expectedResult, expectedError, suiteComment, testComment, benchmark));
         }
       }

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
@@ -104,7 +104,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), is("Wrong type of argument calling heterogenous_list: expected string but was number"));
+      assertThat(ate.getMessage(), is("Invalid argument type calling \"heterogenous_list\": expected string but was number"));
     }
   }
 
@@ -117,7 +117,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Wrong number of arguments calling heterogenous_list: expected 3 but was 2"));
+      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\": expected 3 but was 2"));
     }
   }
 
@@ -132,7 +132,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Wrong number of arguments calling heterogenous_list: expected 3 but was 4"));
+      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\": expected 3 but was 4"));
     }
   }
 
@@ -152,7 +152,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling type_of: expected number but was string"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"type_of\": expected number but was string"));
     }
   }
 
@@ -162,7 +162,7 @@ public class FunctionTest {
       typeOfFunction.call(runtime, Arrays.asList(expressionReference));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling type_of: expected number but was expression"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"type_of\": expected number but was expression"));
     }
   }
 
@@ -172,7 +172,7 @@ public class FunctionTest {
       typeOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling type_of: expected 1 but was 0"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\": expected 1 but was 0"));
     }
     try {
       typeOfFunction.call(runtime, createValueArguments(
@@ -181,7 +181,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling type_of: expected 1 but was 2"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\": expected 1 but was 2"));
     }
   }
 
@@ -198,7 +198,7 @@ public class FunctionTest {
       wantsStringBooleanOrNumberFunction.call(runtime, createValueArguments(runtime.createNull()));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling wants_string_boolean_or_number: expected string, boolean or number but was null"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"wants_string_boolean_or_number\": expected string, boolean or number but was null"));
     }
   }
 
@@ -223,7 +223,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), is("Wrong type of argument calling array_of: expected array of string but was number"));
+      assertThat(ate.getMessage(), is("Invalid argument type calling \"array_of\": expected array of string but was number"));
     }
   }
 
@@ -243,7 +243,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), is("Wrong type of argument calling array_of: expected array of string but was array containing number"));
+      assertThat(ate.getMessage(), is("Invalid argument type calling \"array_of\": expected array of string but was array containing number"));
     }
     try {
       arrayOfFunction.call(runtime, createValueArguments(
@@ -255,7 +255,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), is("Wrong type of argument calling array_of: expected array of string but was array containing string, boolean and number"));
+      assertThat(ate.getMessage(), is("Invalid argument type calling \"array_of\": expected array of string but was array containing string, boolean and number"));
     }
   }
 
@@ -265,7 +265,7 @@ public class FunctionTest {
       arrayOfFunction.call(runtime, Arrays.asList(expressionReference));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), is("Wrong type of argument calling array_of: expected array of string but was expression"));
+      assertThat(ate.getMessage(), is("Invalid argument type calling \"array_of\": expected array of string but was expression"));
     }
   }
 
@@ -297,7 +297,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling wants_string_or_number_array: expected array of string or number but was array containing number and string"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"wants_string_or_number_array\": expected array of string or number but was array containing number and string"));
     }
     try {
       wantsStringOrNumberArrayFunction.call(runtime, createValueArguments(
@@ -310,7 +310,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling wants_string_or_number_array: expected array of string or number but was array containing number, string and null"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"wants_string_or_number_array\": expected array of string or number but was array containing number, string and null"));
     }
   }
 
@@ -320,7 +320,7 @@ public class FunctionTest {
       arrayOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling array_of: expected 1 but was 0"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\": expected 1 but was 0"));
     }
     try {
       arrayOfFunction.call(runtime, createValueArguments(
@@ -329,7 +329,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling array_of: expected 1 but was 2"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\": expected 1 but was 2"));
     }
   }
 
@@ -356,7 +356,7 @@ public class FunctionTest {
       doesNotAcceptExpression.call(runtime, Arrays.asList(expressionReference));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling does_not_accept_expression: expected any value but was expression"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"does_not_accept_expression\": expected any value but was expression"));
     }
   }
 
@@ -395,7 +395,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling accepts_numbers: expected number but was string"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"accepts_numbers\": expected number but was string"));
     }
   }
 
@@ -413,7 +413,7 @@ public class FunctionTest {
       doesNotAcceptExpression.call(runtime, arguments);
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling hello: expected any value but was expression"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"hello\": expected any value but was expression"));
     }
   }
 
@@ -427,7 +427,7 @@ public class FunctionTest {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull()));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling hello: expected at least 3 but was 1"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\": expected at least 3 but was 1"));
     }
   }
 
@@ -441,7 +441,7 @@ public class FunctionTest {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull(), runtime.createNull(), runtime.createNull(), runtime.createNull()));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Wrong number of arguments calling hello: expected at most 3 but was 4"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\": expected at most 3 but was 4"));
     }
   }
 
@@ -470,7 +470,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("Wrong type of argument calling gief_expression: expected expression but was number"));
+      assertThat(ate.getMessage(), containsString("Invalid argument type calling \"gief_expression\": expected expression but was number"));
     }
   }
 }

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -283,10 +283,14 @@ public class ParserTest {
     assertThat(actual, is(expected));
   }
 
-  @Test(expected=ParseException.class)
-  @Ignore
+  @Test
   public void sliceWithZeroStepSize() {
-    compile("[0:1:0]");
+    try {
+      compile("[0:1:0]");
+      fail("Expected ParseException to be thrown");
+    } catch (ParseException pe) {
+      assertThat(pe.getMessage(), is("Unable to compile expression \"[0:1:0]\": invalid value 0 for step size at position 5"));
+    }
   }
 
   @Test
@@ -467,7 +471,7 @@ public class ParserTest {
       compile("to_unicorn(@)");
       fail("Expected ParseException to be thrown");
     } catch (ParseException pe) {
-      assertThat(pe.getMessage(), is("Error while parsing \"to_unicorn(@)\": unknown function \"to_unicorn\" at position 0"));
+      assertThat(pe.getMessage(), is("Unable to compile expression \"to_unicorn(@)\": unknown function \"to_unicorn\" at position 0"));
     }
   }
 
@@ -926,13 +930,13 @@ public class ParserTest {
       compile("`\"fo`o\"`");
       fail("Expected ParseException to be thrown");
     } catch (ParseException pe) {
-      assertThat(pe.getMessage(), is("Error while parsing \"`\"fo`o\"`\": unexpected ` at position 4"));
+      assertThat(pe.getMessage(), is("Unable to compile expression \"`\"fo`o\"`\": syntax error unexpected ` at position 4"));
     }
     try {
       compile("`\"`foo\"`");
       fail("Expected ParseException to be thrown");
     } catch (ParseException pe) {
-      assertThat(pe.getMessage(), is("Error while parsing \"`\"`foo\"`\": unexpected ` at position 2"));
+      assertThat(pe.getMessage(), is("Unable to compile expression \"`\"`foo\"`\": syntax error unexpected ` at position 2"));
     }
   }
 


### PR DESCRIPTION
The JMESPath compliance suite specifies keywords that need to be included in error messages.

This first fixes the compliance test suite to run tests with expected errors, changes the assertions to check for the keywords, and finally changes the error messages to be compliant.