### PR TITLE
Shade ANTRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Check the [releases page](https://github.com/burtcorp/jmespath-java/releases) fo
 
 If you don't want the Jackson implementation you can change the `artifactId` to `jmespath-core`, and if you specifically want to depend only on the Jackson implementation (if we release other implementations in the future) you can change it to `jmespath-jackson`.
 
+### Dependencies
+
+`jmespath-core` has an ANTLR based parser, but the ANTLR runtime artifact has been shaded into the `io.burt.jmespath` package to avoid conflicts with other artifacts that may depend on ANTLR.
+
+`jmespath-jackson` obviously depends on Jackson, specifically Jackson DataBind (`com.fasterxml.jackson.core:jackson-databind`).
+
 ## Basic usage
 
 ```java

--- a/jmespath-core/pom.xml
+++ b/jmespath-core/pom.xml
@@ -19,12 +19,6 @@
       <artifactId>antlr4-runtime</artifactId>
       <version>${antlr.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/jmespath-core/pom.xml
+++ b/jmespath-core/pom.xml
@@ -51,6 +51,29 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <configuration>
+          <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+          <minimizeJar>true</minimizeJar>
+          <relocations>
+            <relocation>
+              <pattern>org.antlr</pattern>
+              <shadedPattern>io.burt.jmespath.antlr</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
ANTLR is a bit of an unfortunate dependency since it's easy to get into version conflicts (we discovered this when we tried using `jmespath-java` with Druid for example).

This uses `maven-shade-plugin` to move all of the ANTLR runtime classes from `org.antlr` to `io.burt.jmespath.antlr`.

It also strips out the classes that we don't need (although we think that there are a few more that we could get rid of, the XPath implementation, for example).

It seems to be working, I got the `jmespath-jruby` to work without problems using the shaded artifact.