### PR TITLE
Check function arity at compile time, and avoid exceptions in the type checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ import java.util.List;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.function.BaseFunction;
 import io.burt.jmespath.function.FunctionArgument;
 import io.burt.jmespath.function.ArgumentConstraints;
@@ -139,8 +140,12 @@ import io.burt.jmespath.jackson.JacksonRuntime;
 FunctionRegistry defaultFunctions = FunctionRegistry.defaultRegistry();
 // And we can create a new registry with additional functions by extending it
 FunctionRegistry customFunctions = defaultFunctions.extend(new SinFunction());
-// We need to create a runtime that uses our custom registry
-JmesPath<JsonNode> runtime = new JacksonRuntime(functionRegistry);
+// To configure the runtime with the registry we need to create a configuration
+RuntimeConfiguration configuration = new RuntimeConfiguration.Builder()
+                                       .withFunctionRegistry(customFunctions)
+                                       .build();
+// And then create a runtime with the configuration
+JmesPath<JsonNode> runtime = new JacksonRuntime(configuration);
 // Now the function is available in expressions
 JsonNode result = runtime.compile("sin(measurements.angle)").search(input);
 ```

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Most of the work a runtime does is converting back and forth between Java types.
 
 Runtime adapters can wrap libraries like [Jackson](https://github.com/FasterXML/jackson) and [Gson](https://github.com/google/gson), but can also make it possible, for example, to search Java beans with JMESPath by translating JMESPath operations to reflection calls. The structure to search doesn't have to be JSON, it just has to be JSON-_like_.
 
-A good starting point for writing a new runtime adapter is reading the code of the existing adapters and the docs for `Adapter` and `BaseAdapter`. There are also JUnit tests in `JmesPathRuntimeTest` and `JmesPathComplianceTest` that can be subclassed and run against any runtime.
+A good starting point for writing a new runtime adapter is reading the code of the existing adapters and the docs for `Adapter` and `BaseAdapter`. There are also JUnit tests in `JmesPathRuntimeTest` and `JmesPathComplianceTest` that can be subclassed and run against any runtime, and that will help you know when your runtime is complete.
 
 ## How to build and run the tests
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ JsonNode result = expression.search(input);
 
 `jmespath-java` comes in three parts: `jmespath-core`, `jmespath-jackson`, and `jmespath-gson`. The former contains the expression parser, core runtime, default functions and a simple runtime adapter that can search structures made up from numbers, strings, booleans, `List` and `Map` available as `io.burt.jmespath.jcf.JcfRuntime` (for "Java Collections Framework"). The latter contains the Jackson and GSON runtime adapters, respectively, and is what you should be using most of the time. The JCF runtime is just for internal development and testing. It primarily exists to test that there's nothing runtime-specific in the implementation.
 
+## Configuration
+
+The runtime can be configured, although there aren't many configuration options yet.
+
+To change the behaviour when a function receives an argument of the wrong type from throwing an exception to returning null you set the `silentTypeErrors` configuration to `true`, for example like this:
+
+```java
+import io.burt.jmespath.RuntimeConfiguration;
+import io.burt.jmespath.jackson.JacksonRuntime;
+
+
+RuntimeConfiguration configuration = new RuntimeConfiguration.Builder()
+                                       .withSilentTypeErrors(true)
+                                       .build();
+JmesPath<JsonNode> jmespath = new JacksonRuntime(configuration);
+```
+
+Many functions don't allow `null` and most of the time you would deal with that by checking for `null` and letting the result be `null`. This configuration makes it possible to skip all those checks and make any type error in a function call behave as if the function call resulted in `null`. It can also be a performance boost by avoiding throwing exceptions when you expect that an expression can sometimes fail with a type error.
+
 ## Extensions
 
 `jmespath-java` is designed to be extensible. You can extend it in two ways: by adding new functions, and by creating different runtime adapters. These are not mutually exclusive, if you write your custom functions the right way you can use them with any runtime, and vice-versa.

--- a/jmespath-core/src/main/java/io/burt/jmespath/Adapter.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/Adapter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Collection;
 
 import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.function.Function;
 import io.burt.jmespath.node.NodeFactory;
 
 /**
@@ -130,6 +131,12 @@ public interface Adapter<T> extends JmesPath<T>, Comparator<T> {
    * Returns a number value containing the specified integer.
    */
   T createNumber(long n);
+
+  /**
+   * Throws an exception or returns a fallback value when a type check fails
+   * during a function call evaluation.
+   */
+  T handleArgumentTypeError(Function function, String expectedType, String actualType);
 
   /**
    * Returns a function registry that can be used by the expression compiler

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
@@ -32,6 +32,7 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
     '\"', '\"'
   );
 
+  private final RuntimeConfiguration configuration;
   private final FunctionRegistry functionRegistry;
   private final NodeFactory<T> nodeFactory;
 
@@ -39,18 +40,15 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
    * Create a new runtime with a default function registry.
    */
   public BaseRuntime() {
-    this(null);
+    this(RuntimeConfiguration.defaultConfiguration());
   }
 
   /**
-   * Create a new runtime with a custom function registry.
+   * Create a new runtime with configuration.
    */
-  public BaseRuntime(FunctionRegistry functionRegistry) {
-    if (functionRegistry == null) {
-      this.functionRegistry = FunctionRegistry.defaultRegistry();
-    } else {
-      this.functionRegistry = functionRegistry;
-    }
+  public BaseRuntime(RuntimeConfiguration configuration) {
+    this.configuration = configuration;
+    this.functionRegistry = configuration.functionRegistry();
     this.nodeFactory = new StandardNodeFactory<>(this);
   }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
@@ -137,9 +137,17 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
     return true;
   }
 
+  /**
+   * Throws {@link ArgumentTypeException} unless {@link RuntimeConfiguration#silentTypeErrors}
+   * is true, in which case it returns a null value (<em>not</em> Java <code>null</code>).
+   */
   @Override
   public T handleArgumentTypeError(Function function, String expectedType, String actualType) {
-    throw new ArgumentTypeException(function, expectedType, actualType);
+    if (configuration.silentTypeErrors()) {
+      return createNull();
+    } else {
+      throw new ArgumentTypeException(function, expectedType, actualType);
+    }
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
@@ -32,9 +32,9 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
     '\"', '\"'
   );
 
-  private final RuntimeConfiguration configuration;
   private final FunctionRegistry functionRegistry;
   private final NodeFactory<T> nodeFactory;
+  private final boolean silentTypeErrors;
 
   /**
    * Create a new runtime with a default function registry.
@@ -47,7 +47,7 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
    * Create a new runtime with configuration.
    */
   public BaseRuntime(RuntimeConfiguration configuration) {
-    this.configuration = configuration;
+    this.silentTypeErrors = configuration.silentTypeErrors();
     this.functionRegistry = configuration.functionRegistry();
     this.nodeFactory = new StandardNodeFactory<>(this);
   }
@@ -143,7 +143,7 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
    */
   @Override
   public T handleArgumentTypeError(Function function, String expectedType, String actualType) {
-    if (configuration.silentTypeErrors()) {
+    if (silentTypeErrors) {
       return createNull();
     } else {
       throw new ArgumentTypeException(function, expectedType, actualType);

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import io.burt.jmespath.parser.ExpressionParser;
 import io.burt.jmespath.function.FunctionRegistry;
 import io.burt.jmespath.function.Function;
-import io.burt.jmespath.function.ArityException;
 import io.burt.jmespath.function.ArgumentTypeException;
 import io.burt.jmespath.node.NodeFactory;
 import io.burt.jmespath.node.StandardNodeFactory;

--- a/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/BaseRuntime.java
@@ -6,6 +6,9 @@ import java.util.Collection;
 
 import io.burt.jmespath.parser.ExpressionParser;
 import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.function.Function;
+import io.burt.jmespath.function.ArityException;
+import io.burt.jmespath.function.ArgumentTypeException;
 import io.burt.jmespath.node.NodeFactory;
 import io.burt.jmespath.node.StandardNodeFactory;
 import io.burt.jmespath.util.StringEscapeHelper;
@@ -134,6 +137,11 @@ public abstract class BaseRuntime<T> implements Adapter<T> {
       }
     }
     return true;
+  }
+
+  @Override
+  public T handleArgumentTypeError(Function function, String expectedType, String actualType) {
+    throw new ArgumentTypeException(function, expectedType, actualType);
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/RuntimeConfiguration.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/RuntimeConfiguration.java
@@ -1,0 +1,40 @@
+package io.burt.jmespath;
+
+import io.burt.jmespath.function.FunctionRegistry;
+
+public class RuntimeConfiguration {
+  private final FunctionRegistry functionRegistry;
+
+  private RuntimeConfiguration(Builder builder) {
+    this.functionRegistry = builder.functionRegistry;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static RuntimeConfiguration defaultConfiguration() {
+    return builder().build();
+  }
+
+  public static class Builder {
+    protected FunctionRegistry functionRegistry;
+
+    public Builder() {
+      this.functionRegistry = FunctionRegistry.defaultRegistry();
+    }
+
+    public RuntimeConfiguration build() {
+      return new RuntimeConfiguration(this);
+    }
+
+    public Builder withFunctionRegistry(FunctionRegistry functionRegistry) {
+      this.functionRegistry = functionRegistry;
+      return this;
+    }
+  }
+
+  public FunctionRegistry functionRegistry() {
+    return functionRegistry;
+  }
+}

--- a/jmespath-core/src/main/java/io/burt/jmespath/RuntimeConfiguration.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/RuntimeConfiguration.java
@@ -4,9 +4,19 @@ import io.burt.jmespath.function.FunctionRegistry;
 
 public class RuntimeConfiguration {
   private final FunctionRegistry functionRegistry;
+  private final boolean silentTypeErrors;
 
   private RuntimeConfiguration(Builder builder) {
     this.functionRegistry = builder.functionRegistry;
+    this.silentTypeErrors = builder.silentTypeErrors;
+  }
+
+  public FunctionRegistry functionRegistry() {
+    return functionRegistry;
+  }
+
+  public boolean silentTypeErrors() {
+    return silentTypeErrors;
   }
 
   public static Builder builder() {
@@ -19,6 +29,7 @@ public class RuntimeConfiguration {
 
   public static class Builder {
     protected FunctionRegistry functionRegistry;
+    protected boolean silentTypeErrors;
 
     public Builder() {
       this.functionRegistry = FunctionRegistry.defaultRegistry();
@@ -32,9 +43,10 @@ public class RuntimeConfiguration {
       this.functionRegistry = functionRegistry;
       return this;
     }
-  }
 
-  public FunctionRegistry functionRegistry() {
-    return functionRegistry;
+    public Builder withSilentTypeErrors(boolean silentTypeErrors) {
+      this.silentTypeErrors = silentTypeErrors;
+      return this;
+    }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
@@ -14,11 +14,15 @@ public interface ArgumentConstraint {
    * <p>
    * Most constraints will consume one or more elements from the iterator, but
    * constraints that represents optional arguments may choose not to.
-   *
-   * @throws ArityException when there are not enough arguments left to satisfy the constraint
-   * @throws ArgumentTypeException when an argument does not satisfy the constraint
+   * <p>
+   * At the first error an {@link ArgumentError} is returned. If no errors are
+   * discovered <code>null</code> will be returned.
+   * <p>
+   * When <code>expectNoRemainingArguments</code> is true and there remain
+   * elements in the iterator after all checks have been performed an error will
+   * be returned.
    */
-  <T> void check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments);
+  <T> ArgumentError check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments, boolean expectNoRemainingArguments);
 
   /**
    * @return the minimum number of arguments required.

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
@@ -15,14 +15,17 @@ public interface ArgumentConstraint {
    * Most constraints will consume one or more elements from the iterator, but
    * constraints that represents optional arguments may choose not to.
    * <p>
-   * At the first error an {@link ArgumentError} is returned. If no errors are
-   * discovered <code>null</code> will be returned.
+   * Any errors found will be returned as an iterator of {@link ArgumentError}.
+   * When this iterator is empty no errors were found. The iterator may or may
+   * not contain all errors that could be found, errors may make the checker
+   * return as soon as they are encountered and not attempt to check the
+   * remaining arguments.
    * <p>
    * When <code>expectNoRemainingArguments</code> is true and there remain
    * elements in the iterator after all checks have been performed an error will
    * be returned.
    */
-  <T> ArgumentError check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments, boolean expectNoRemainingArguments);
+  <T> Iterator<ArgumentError> check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments, boolean expectNoRemainingArguments);
 
   /**
    * @return the minimum number of arguments required.

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentError.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentError.java
@@ -1,0 +1,27 @@
+package io.burt.jmespath.function;
+
+public class ArgumentError {
+  public static class ArgumentTypeError extends ArgumentError {
+    private final String expectedType;
+    private final String actualType;
+
+    public ArgumentTypeError(String expectedType, String actualType) {
+      this.expectedType = expectedType;
+      this.actualType = actualType;
+    }
+
+    public String expectedType() { return expectedType; }
+
+    public String actualType() { return actualType; }
+  }
+
+  public static class ArityError extends ArgumentError { }
+
+  public static ArgumentError createArityError() {
+    return new ArityError();
+  }
+
+  public static ArgumentTypeError createArgumentTypeError(String expectedType, String actualType) {
+    return new ArgumentTypeError(expectedType, actualType);
+  }
+}

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentTypeException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentTypeException.java
@@ -2,11 +2,11 @@ package io.burt.jmespath.function;
 
 @SuppressWarnings("serial")
 public class ArgumentTypeException extends FunctionCallException {
-  public ArgumentTypeException(String functionName, String expectedType, String actualType) {
-    this(functionName, expectedType, actualType, null);
+  public ArgumentTypeException(Function function, String expectedType, String actualType) {
+    this(function, expectedType, actualType, null);
   }
 
-  public ArgumentTypeException(String functionName, String expectedType, String actualType, Throwable cause) {
-    super(String.format("Invalid argument type calling \"%s\": expected %s but was %s", functionName, expectedType, actualType), cause);
+  public ArgumentTypeException(Function function, String expectedType, String actualType, Throwable cause) {
+    super(String.format("Invalid argument type calling \"%s\": expected %s but was %s", function.name(), expectedType, actualType), cause);
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -111,23 +111,14 @@ public abstract class BaseFunction implements Function {
    */
   @Override
   public <T> T call(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
-    checkArguments(runtime, arguments);
-    return callFunction(runtime, arguments);
-  }
-
-  /**
-   * Checks the arguments against the argument constraints.
-   *
-   * @throws ArgumentTypeException when an arguments type does not match the constraints
-   * @throws ArityException when there are too few or too many arguments
-   */
-  protected <T> void checkArguments(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
     Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
     ArgumentError error = argumentConstraints.check(runtime, argumentIterator, true);
-    if (error != null) {
+    if (error == null) {
+      return callFunction(runtime, arguments);
+    } else {
       if (error instanceof ArgumentError.ArgumentTypeError) {
         ArgumentError.ArgumentTypeError e = (ArgumentError.ArgumentTypeError) error;
-        runtime.handleArgumentTypeError(this, e.expectedType(), e.actualType());
+        return runtime.handleArgumentTypeError(this, e.expectedType(), e.actualType());
       } else if (error instanceof ArgumentError.ArityError) {
         throw new IllegalStateException(ArityException.createMessage(this, arguments.size(), true));
       } else {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -112,10 +112,11 @@ public abstract class BaseFunction implements Function {
   @Override
   public <T> T call(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
     Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
-    ArgumentError error = argumentConstraints.check(runtime, argumentIterator, true);
-    if (error == null) {
+    Iterator<ArgumentError> maybeError = argumentConstraints.check(runtime, argumentIterator, true);
+    if (!maybeError.hasNext()) {
       return callFunction(runtime, arguments);
     } else {
+      ArgumentError error = maybeError.next();
       if (error instanceof ArgumentError.ArgumentTypeError) {
         ArgumentError.ArgumentTypeError e = (ArgumentError.ArgumentTypeError) error;
         return runtime.handleArgumentTypeError(this, e.expectedType(), e.actualType());

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -125,13 +125,13 @@ public abstract class BaseFunction implements Function {
     Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
     ArgumentError error = argumentConstraints.check(runtime, argumentIterator, true);
     if (error != null) {
-      if (error instanceof ArgumentError.ArityError) {
-        throw new ArityException(this, arguments.size());
-      } else if (error instanceof ArgumentError.ArgumentTypeError) {
+      if (error instanceof ArgumentError.ArgumentTypeError) {
         ArgumentError.ArgumentTypeError e = (ArgumentError.ArgumentTypeError) error;
-        throw new ArgumentTypeException(this, e.expectedType(), e.actualType());
+        runtime.handleArgumentTypeError(this, e.expectedType(), e.actualType());
+      } else if (error instanceof ArgumentError.ArityError) {
+        throw new IllegalStateException(ArityException.createMessage(this, arguments.size(), true));
       } else {
-        throw new IllegalStateException(String.format("Unexpected error while type checking: %s", error.getClass().getName()));
+        throw new IllegalStateException(String.format("Unexpected error while type checking arguments to \"%s\": %s", name(), error.getClass().getName()));
       }
     }
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -129,7 +129,7 @@ public abstract class BaseFunction implements Function {
         throw new ArityException(this, arguments.size());
       } else if (error instanceof ArgumentError.ArgumentTypeError) {
         ArgumentError.ArgumentTypeError e = (ArgumentError.ArgumentTypeError) error;
-        throw new ArgumentTypeException(name(), e.expectedType(), e.actualType());
+        throw new ArgumentTypeException(this, e.expectedType(), e.actualType());
       } else {
         throw new IllegalStateException(String.format("Unexpected error while type checking: %s", error.getClass().getName()));
       }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -122,16 +122,17 @@ public abstract class BaseFunction implements Function {
    * @throws ArityException when there are too few or too many arguments
    */
   protected <T> void checkArguments(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
-    try {
-      Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
-      argumentConstraints.check(runtime, argumentIterator);
-      if (argumentIterator.hasNext()) {
+    Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
+    ArgumentError error = argumentConstraints.check(runtime, argumentIterator, true);
+    if (error != null) {
+      if (error instanceof ArgumentError.ArityError) {
         throw new ArityException(this, arguments.size());
+      } else if (error instanceof ArgumentError.ArgumentTypeError) {
+        ArgumentError.ArgumentTypeError e = (ArgumentError.ArgumentTypeError) error;
+        throw new ArgumentTypeException(name(), e.expectedType(), e.actualType());
+      } else {
+        throw new IllegalStateException(String.format("Unexpected error while type checking: %s", error.getClass().getName()));
       }
-    } catch (ArgumentConstraints.InternalArityException e) {
-      throw new ArityException(this, arguments.size(), e);
-    } catch (ArgumentConstraints.InternalArgumentTypeException e) {
-      throw new ArgumentTypeException(name(), e.expectedType(), e.actualType(), e);
     }
   }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
@@ -1,23 +1,11 @@
 package io.burt.jmespath.function;
 
-import java.util.Iterator;
-import java.util.List;
-
 import io.burt.jmespath.Adapter;
-import io.burt.jmespath.JmesPathType;
-import io.burt.jmespath.Expression;
 
 /**
  * Helper base class for higher order comparison functions like max_by and min_by.
  */
-public abstract class CompareByFunction extends BaseFunction {
-  public CompareByFunction() {
-    super(
-      ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.OBJECT)),
-      ArgumentConstraints.expression()
-    );
-  }
-
+public abstract class CompareByFunction extends ComparingFunction {
   /**
    * Subclasses override this method to decide whether the greatest or least
    * element sorts first.
@@ -25,39 +13,41 @@ public abstract class CompareByFunction extends BaseFunction {
   protected abstract boolean sortsBefore(int compareResult);
 
   @Override
-  protected <T> T callFunction(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
-    Iterator<T> elements = runtime.toList(arguments.get(0).value()).iterator();
-    Expression<T> expression = arguments.get(1).expression();
-    if (elements.hasNext()) {
-      T result = elements.next();
-      T resultValue = expression.search(result);
-      JmesPathType resultValueType = runtime.typeOf(resultValue);
-      boolean expectNumbers = true;
-      if (resultValueType == JmesPathType.STRING) {
-        expectNumbers = false;
-      } else if (resultValueType != JmesPathType.NUMBER) {
-        return runtime.handleArgumentTypeError(this, "number or string", resultValueType.toString());
+  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue) {
+    return new ComparingAggregator<T>(runtime, element, elementValue);
+  }
+
+  @Override
+  protected <T> T createNullValue(Adapter<T> runtime) {
+    return runtime.createNull();
+  }
+
+  private class ComparingAggregator<V> extends ComparingFunction.Aggregator<V> {
+    private Pair<V> current;
+
+    public ComparingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {
+      super(runtime);
+      this.current = new Pair<V>(initialValue, initialElement);
+    }
+
+    protected void aggregate(V candidate, V candidateValue) {
+      if (sortsBefore(runtime.compare(candidateValue, current.elementValue))) {
+        current = new Pair<V>(candidateValue, candidate);
       }
-      while (elements.hasNext()) {
-        T candidate = elements.next();
-        T candidateValue = expression.search(candidate);
-        if (checkType(runtime, candidateValue, expectNumbers)) {
-          if (sortsBefore(runtime.compare(candidateValue, resultValue))) {
-            result = candidate;
-            resultValue = candidateValue;
-          }
-        } else {
-          return runtime.handleArgumentTypeError(this, expectNumbers ? "number" : "string", runtime.typeOf(candidateValue).toString());
-        }
-      }
-      return result;
-    } else {
-      return runtime.createNull();
+    }
+  
+    protected V result() {
+      return current.element;
     }
   }
 
-  private <T> boolean checkType(Adapter<T> runtime, T candidateValue, boolean expectNumbers) {
-    JmesPathType candidateType = runtime.typeOf(candidateValue);
-    return (expectNumbers && candidateType == JmesPathType.NUMBER) || (!expectNumbers && candidateType == JmesPathType.STRING);
+  private static class Pair<U> {
+    public final U elementValue;
+    public final U element;
+
+    public Pair(U elementValue, U element) {
+      this.elementValue = elementValue;
+      this.element = element;
+    }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
@@ -5,7 +5,7 @@ import io.burt.jmespath.Adapter;
 /**
  * Helper base class for higher order comparison functions like max_by and min_by.
  */
-public abstract class CompareByFunction extends ComparingFunction {
+public abstract class CompareByFunction extends TransformByFunction {
   /**
    * Subclasses override this method to decide whether the greatest or least
    * element sorts first.
@@ -13,7 +13,7 @@ public abstract class CompareByFunction extends ComparingFunction {
   protected abstract boolean sortsBefore(int compareResult);
 
   @Override
-  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
+  protected <T> TransformByFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
     return new ComparingAggregator<T>(runtime, element, elementValue);
   }
 
@@ -22,7 +22,7 @@ public abstract class CompareByFunction extends ComparingFunction {
     return runtime.createNull();
   }
 
-  private class ComparingAggregator<V> extends ComparingFunction.Aggregator<V> {
+  private class ComparingAggregator<V> extends TransformByFunction.Aggregator<V> {
     private Pair<V> current;
 
     public ComparingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
@@ -27,12 +27,12 @@ public abstract class CompareByFunction extends ComparingFunction {
 
     public ComparingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {
       super(runtime);
-      this.current = new Pair<V>(initialValue, initialElement);
+      this.current = new Pair<V>(initialElement, initialValue);
     }
 
     protected void aggregate(V candidate, V candidateValue) {
       if (sortsBefore(runtime.compare(candidateValue, current.elementValue))) {
-        current = new Pair<V>(candidateValue, candidate);
+        current = new Pair<V>(candidate, candidateValue);
       }
     }
   
@@ -42,12 +42,12 @@ public abstract class CompareByFunction extends ComparingFunction {
   }
 
   private static class Pair<U> {
-    public final U elementValue;
     public final U element;
+    public final U elementValue;
 
-    public Pair(U elementValue, U element) {
-      this.elementValue = elementValue;
+    public Pair(U element, U elementValue) {
       this.element = element;
+      this.elementValue = elementValue;
     }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
@@ -51,7 +51,7 @@ public abstract class CompareByFunction extends BaseFunction {
     if (runtime.typeOf(resultValue) == JmesPathType.STRING) {
       return false;
     } else if (runtime.typeOf(resultValue) != JmesPathType.NUMBER) {
-      throw new ArgumentTypeException(name(), "number or string", runtime.typeOf(resultValue).toString());
+      throw new ArgumentTypeException(this, "number or string", runtime.typeOf(resultValue).toString());
     }
     return true;
   }
@@ -59,9 +59,9 @@ public abstract class CompareByFunction extends BaseFunction {
   private <T> void checkType(Adapter<T> runtime, T candidateValue, boolean expectNumbers) {
     JmesPathType candidateType = runtime.typeOf(candidateValue);
     if (expectNumbers && candidateType != JmesPathType.NUMBER) {
-      throw new ArgumentTypeException(name(), "number", candidateType.toString());
+      throw new ArgumentTypeException(this, "number", candidateType.toString());
     } else if (!expectNumbers && candidateType != JmesPathType.STRING) {
-      throw new ArgumentTypeException(name(), "string", candidateType.toString());
+      throw new ArgumentTypeException(this, "string", candidateType.toString());
     }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/CompareByFunction.java
@@ -13,7 +13,7 @@ public abstract class CompareByFunction extends ComparingFunction {
   protected abstract boolean sortsBefore(int compareResult);
 
   @Override
-  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue) {
+  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
     return new ComparingAggregator<T>(runtime, element, elementValue);
   }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ComparingFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ComparingFunction.java
@@ -33,7 +33,7 @@ public abstract class ComparingFunction extends BaseFunction {
       } else if (elementValueType != JmesPathType.NUMBER) {
         return runtime.handleArgumentTypeError(this, "number or string", elementValueType.toString());
       }
-      Aggregator<T> aggregator = createAggregator(runtime, element, elementValue);
+      Aggregator<T> aggregator = createAggregator(runtime, elementsList.size(), element, elementValue);
       while (elements.hasNext()) {
         T candidate = elements.next();
         T candidateValue = expression.search(candidate);
@@ -49,7 +49,7 @@ public abstract class ComparingFunction extends BaseFunction {
     }
   }
 
-  protected abstract <T> Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue);
+  protected abstract <T> Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue);
 
   protected abstract <T> T createNullValue(Adapter<T> runtime);
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ComparingFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ComparingFunction.java
@@ -1,0 +1,72 @@
+package io.burt.jmespath.function;
+
+import java.util.Iterator;
+import java.util.List;
+
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.Expression;
+
+/**
+ * Helper base class for higher order comparison functions like sort_by, max_by and min_by.
+ */
+public abstract class ComparingFunction extends BaseFunction {
+  public ComparingFunction() {
+    super(
+      ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.OBJECT)),
+      ArgumentConstraints.expression()
+    );
+  }
+
+  @Override
+  protected <T> T callFunction(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
+    List<T> elementsList = runtime.toList(arguments.get(0).value());
+    Iterator<T> elements = elementsList.iterator();
+    Expression<T> expression = arguments.get(1).expression();
+    if (elements.hasNext()) {
+      T element = elements.next();
+      T elementValue = expression.search(element);
+      JmesPathType elementValueType = runtime.typeOf(elementValue);
+      boolean expectNumbers = true;
+      if (elementValueType == JmesPathType.STRING) {
+        expectNumbers = false;
+      } else if (elementValueType != JmesPathType.NUMBER) {
+        return runtime.handleArgumentTypeError(this, "number or string", elementValueType.toString());
+      }
+      Aggregator<T> aggregator = createAggregator(runtime, element, elementValue);
+      while (elements.hasNext()) {
+        T candidate = elements.next();
+        T candidateValue = expression.search(candidate);
+        if (checkType(runtime, candidateValue, expectNumbers)) {
+          aggregator.aggregate(candidate, candidateValue);
+        } else {
+          return runtime.handleArgumentTypeError(this, expectNumbers ? "number" : "string", runtime.typeOf(candidateValue).toString());
+        }
+      }
+      return aggregator.result();
+    } else {
+      return createNullValue(runtime);
+    }
+  }
+
+  protected abstract <T> Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue);
+
+  protected abstract <T> T createNullValue(Adapter<T> runtime);
+
+  public static abstract class Aggregator<V> {
+    protected final Adapter<V> runtime;
+
+    public Aggregator(Adapter<V> runtime) {
+      this.runtime = runtime;
+    }
+
+    protected abstract void aggregate(V candidate, V candidateValue);
+
+    protected abstract V result();
+  }
+
+  private <T> boolean checkType(Adapter<T> runtime, T candidateValue, boolean expectNumbers) {
+    JmesPathType candidateType = runtime.typeOf(candidateValue);
+    return (expectNumbers && candidateType == JmesPathType.NUMBER) || (!expectNumbers && candidateType == JmesPathType.STRING);
+  }
+}

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -9,8 +9,8 @@ import io.burt.jmespath.Adapter;
 
 public class SortByFunction extends ComparingFunction {
   @Override
-  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue) {
-    return new SortingAggregator<T>(runtime, element, elementValue);
+  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
+    return new SortingAggregator<T>(runtime, elementCount, element, elementValue);
   }
 
   @Override
@@ -21,9 +21,9 @@ public class SortByFunction extends ComparingFunction {
   private class SortingAggregator<V> extends ComparingFunction.Aggregator<V> {
     private List<Pair<V>> pairs;
 
-    public SortingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {
+    public SortingAggregator(Adapter<V> runtime, int elementCount, V initialElement, V initialValue) {
       super(runtime);
-      this.pairs = new ArrayList<>();
+      this.pairs = new ArrayList<>(elementCount);
       this.pairs.add(new Pair<V>(initialElement, initialValue));
     }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -1,65 +1,46 @@
 package io.burt.jmespath.function;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
 
 import io.burt.jmespath.Adapter;
-import io.burt.jmespath.Expression;
-import io.burt.jmespath.JmesPathType;
 
-public class SortByFunction extends BaseFunction {
-  public SortByFunction() {
-    super(
-      ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.OBJECT)),
-      ArgumentConstraints.expression()
-    );
+public class SortByFunction extends ComparingFunction {
+  @Override
+  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, T element, T elementValue) {
+    return new SortingAggregator<T>(runtime, element, elementValue);
   }
 
   @Override
-  protected <T> T callFunction(final Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
-    List<T> elementsList = runtime.toList(arguments.get(0).value());
-    Expression<T> expression = arguments.get(1).expression();
-    Iterator<T> elements = elementsList.iterator();
-    if (elements.hasNext()) {
-      List<Pair<T>> pairs = new ArrayList<>(elementsList.size());
-      T element = elements.next();
-      T transformedElement = expression.search(element);
-      JmesPathType transformedElementType = runtime.typeOf(transformedElement);
-      boolean expectNumbers = true;
-      if (transformedElementType == JmesPathType.STRING) {
-        expectNumbers = false;
-      } else if (transformedElementType != JmesPathType.NUMBER) {
-        return runtime.handleArgumentTypeError(this, "number or string", transformedElementType.toString());
-      }
-      pairs.add(new Pair<T>(transformedElement, element));
-      while (elements.hasNext()) {
-        element = elements.next();
-        transformedElement = expression.search(element);
-        if (checkType(runtime, transformedElement, expectNumbers)) {
-          pairs.add(new Pair<T>(transformedElement, element));
-        } else {
-          return runtime.handleArgumentTypeError(this, expectNumbers ? "number" : "string", runtime.typeOf(transformedElement).toString());
-        }
-      }
-      return runtime.createArray(sortAndFlatten(runtime, pairs));
-    } else {
-      return runtime.createArray(new ArrayList<T>());
-    }
+  protected <T> T createNullValue(Adapter<T> runtime) {
+    return runtime.createArray(new ArrayList<T>());
   }
 
-  private <T> boolean checkType(Adapter<T> runtime, T transformedElement, boolean expectNumbers) {
-    JmesPathType elementType = runtime.typeOf(transformedElement);
-    return (expectNumbers && elementType == JmesPathType.NUMBER) || (!expectNumbers && elementType == JmesPathType.STRING);
+  private class SortingAggregator<V> extends ComparingFunction.Aggregator<V> {
+    private List<Pair<V>> pairs;
+
+    public SortingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {
+      super(runtime);
+      this.pairs = new ArrayList<>();
+      this.pairs.add(new Pair<V>(initialValue, initialElement));
+    }
+
+    protected void aggregate(V candidate, V candidateValue) {
+      pairs.add(new Pair<V>(candidateValue, candidate));
+    }
+  
+    protected V result() {
+      return runtime.createArray(sortAndFlatten(runtime, pairs));
+    }
   }
 
   private <T> List<T> sortAndFlatten(final Adapter<T> runtime, List<Pair<T>> pairs) {
     Collections.sort(pairs, new Comparator<Pair<T>>() {
       @Override
       public int compare(Pair<T> a, Pair<T> b) {
-        return runtime.compare(a.transformedElement, b.transformedElement);
+        return runtime.compare(a.elementValue, b.elementValue);
       }
     });
     List<T> sorted = new ArrayList<>(pairs.size());
@@ -70,11 +51,11 @@ public class SortByFunction extends BaseFunction {
   }
 
   private static class Pair<U> {
-    public final U transformedElement;
+    public final U elementValue;
     public final U element;
 
-    public Pair(U transformedElement, U element) {
-      this.transformedElement = transformedElement;
+    public Pair(U elementValue, U element) {
+      this.elementValue = elementValue;
       this.element = element;
     }
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -46,7 +46,7 @@ public class SortByFunction extends BaseFunction {
     if (elementType == JmesPathType.STRING) {
       return false;
     } else if (elementType != JmesPathType.NUMBER) {
-      throw new ArgumentTypeException(name(), "number or string", elementType.toString());
+      throw new ArgumentTypeException(this, "number or string", elementType.toString());
     }
     return true;
   }
@@ -54,9 +54,9 @@ public class SortByFunction extends BaseFunction {
   private <T> void checkType(Adapter<T> runtime, T transformedElement, boolean expectNumbers) {
     JmesPathType elementType = runtime.typeOf(transformedElement);
     if (expectNumbers && elementType != JmesPathType.NUMBER) {
-      throw new ArgumentTypeException(name(), "number", elementType.toString());
+      throw new ArgumentTypeException(this, "number", elementType.toString());
     } else if (!expectNumbers && elementType != JmesPathType.STRING) {
-      throw new ArgumentTypeException(name(), "string", elementType.toString());
+      throw new ArgumentTypeException(this, "string", elementType.toString());
     }
   }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -34,20 +34,20 @@ public class SortByFunction extends ComparingFunction {
     protected V result() {
       return runtime.createArray(sortAndFlatten(runtime, pairs));
     }
-  }
 
-  private <T> List<T> sortAndFlatten(final Adapter<T> runtime, List<Pair<T>> pairs) {
-    Collections.sort(pairs, new Comparator<Pair<T>>() {
-      @Override
-      public int compare(Pair<T> a, Pair<T> b) {
-        return runtime.compare(a.elementValue, b.elementValue);
+    private <T> List<T> sortAndFlatten(final Adapter<T> runtime, List<Pair<T>> pairs) {
+      Collections.sort(pairs, new Comparator<Pair<T>>() {
+        @Override
+        public int compare(Pair<T> a, Pair<T> b) {
+          return runtime.compare(a.elementValue, b.elementValue);
+        }
+      });
+      List<T> sorted = new ArrayList<>(pairs.size());
+      for (Pair<T> pair : pairs) {
+        sorted.add(pair.element);
       }
-    });
-    List<T> sorted = new ArrayList<>(pairs.size());
-    for (Pair<T> pair : pairs) {
-      sorted.add(pair.element);
+      return sorted;
     }
-    return sorted;
   }
 
   private static class Pair<U> {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -7,9 +7,9 @@ import java.util.Comparator;
 
 import io.burt.jmespath.Adapter;
 
-public class SortByFunction extends ComparingFunction {
+public class SortByFunction extends TransformByFunction {
   @Override
-  protected <T> ComparingFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
+  protected <T> TransformByFunction.Aggregator<T> createAggregator(Adapter<T> runtime, int elementCount, T element, T elementValue) {
     return new SortingAggregator<T>(runtime, elementCount, element, elementValue);
   }
 
@@ -18,7 +18,7 @@ public class SortByFunction extends ComparingFunction {
     return runtime.createArray(new ArrayList<T>());
   }
 
-  private class SortingAggregator<V> extends ComparingFunction.Aggregator<V> {
+  private class SortingAggregator<V> extends TransformByFunction.Aggregator<V> {
     private List<Pair<V>> pairs;
 
     public SortingAggregator(Adapter<V> runtime, int elementCount, V initialElement, V initialValue) {

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/SortByFunction.java
@@ -24,11 +24,11 @@ public class SortByFunction extends ComparingFunction {
     public SortingAggregator(Adapter<V> runtime, V initialElement, V initialValue) {
       super(runtime);
       this.pairs = new ArrayList<>();
-      this.pairs.add(new Pair<V>(initialValue, initialElement));
+      this.pairs.add(new Pair<V>(initialElement, initialValue));
     }
 
     protected void aggregate(V candidate, V candidateValue) {
-      pairs.add(new Pair<V>(candidateValue, candidate));
+      pairs.add(new Pair<V>(candidate, candidateValue));
     }
   
     protected V result() {
@@ -51,12 +51,12 @@ public class SortByFunction extends ComparingFunction {
   }
 
   private static class Pair<U> {
-    public final U elementValue;
     public final U element;
+    public final U elementValue;
 
-    public Pair(U elementValue, U element) {
-      this.elementValue = elementValue;
+    public Pair(U element, U elementValue) {
       this.element = element;
+      this.elementValue = elementValue;
     }
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/TransformByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/TransformByFunction.java
@@ -10,8 +10,8 @@ import io.burt.jmespath.Expression;
 /**
  * Helper base class for higher order comparison functions like sort_by, max_by and min_by.
  */
-public abstract class ComparingFunction extends BaseFunction {
-  public ComparingFunction() {
+public abstract class TransformByFunction extends BaseFunction {
+  public TransformByFunction() {
     super(
       ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.OBJECT)),
       ArgumentConstraints.expression()

--- a/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfRuntime.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import io.burt.jmespath.BaseRuntime;
 import io.burt.jmespath.JmesPathType;
 import io.burt.jmespath.RuntimeConfiguration;
-import io.burt.jmespath.function.FunctionRegistry;
 
 import static io.burt.jmespath.JmesPathType.*;
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfRuntime.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/jcf/JcfRuntime.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 
 import io.burt.jmespath.BaseRuntime;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.function.FunctionRegistry;
 
 import static io.burt.jmespath.JmesPathType.*;
@@ -17,8 +18,8 @@ public class JcfRuntime extends BaseRuntime<Object> {
     super();
   }
 
-  public JcfRuntime(FunctionRegistry functionRegistry) {
-    super(functionRegistry);
+  public JcfRuntime(RuntimeConfiguration configuration) {
+    super(configuration);
   }
 
   @Override

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathComplianceTest.java
@@ -18,11 +18,6 @@ import java.util.jar.JarEntry;
 import org.junit.runner.RunWith;
 import org.hamcrest.Matcher;
 
-import io.burt.jmespath.parser.ParseException;
-import io.burt.jmespath.function.ArgumentTypeException;
-import io.burt.jmespath.function.ArityException;
-import io.burt.jmespath.function.FunctionCallException;
-
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Collection;
 import java.util.Collections;
 
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.parser.ParseException;
 import io.burt.jmespath.function.ArgumentTypeException;
 
@@ -33,10 +34,14 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 
 public abstract class JmesPathRuntimeTest<T> {
+  private Adapter<T> runtime = createRuntime(RuntimeConfiguration.defaultConfiguration());
+
   protected T contact;
   protected T cloudtrail;
 
-  protected abstract Adapter<T> runtime();
+  protected Adapter<T> runtime() { return runtime; }
+
+  protected abstract Adapter<T> createRuntime(RuntimeConfiguration configuration);
 
   protected T loadExample(String path) {
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(JmesPathRuntimeTest.class.getResourceAsStream(path), Charset.forName("UTF-8")))) {

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -900,6 +900,22 @@ public abstract class JmesPathRuntimeTest<T> {
   }
 
   @Test
+  public void withSilentTypeErrorsTheWrongTypeOfArgumentMakesFunctionsReturnNull() {
+    Adapter<T> rt = createRuntime(RuntimeConfiguration.builder().withSilentTypeErrors(true).build());
+    T result = rt.compile("abs('foo')").search(parse("{}"));
+    assertThat(result, is(jsonNull()));
+  }
+
+  @Test
+  public void withSilentTypeErrorsTheWrongTypeOfArgumentMakesHigherOrderFunctionsReturnNull() {
+    Adapter<T> rt = createRuntime(RuntimeConfiguration.builder().withSilentTypeErrors(true).build());
+    T result1 = rt.compile("sort_by(@, &foo)").search(parse("[{\"foo\": 3}, {\"foo\": \"bar\"}, {\"foo\": 1}]"));
+    T result2 = rt.compile("min_by(@, &foo)").search(parse("[{\"foo\": 3}, {\"foo\": \"bar\"}, {\"foo\": 1}]"));
+    assertThat(result1, is(jsonNull()));
+    assertThat(result2, is(jsonNull()));
+  }
+
+  @Test
   public void absReturnsTheAbsoluteValueOfANumber() {
     T result1 = search("abs(`-1`)", parse("{}"));
     T result2 = search("abs(`1`)", parse("{}"));

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -24,13 +24,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 
 public abstract class JmesPathRuntimeTest<T> {

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
@@ -116,8 +116,8 @@ public class FunctionTest {
         runtime.createString("hello")
       ));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 2)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 2)"));
     }
   }
 
@@ -131,8 +131,8 @@ public class FunctionTest {
         runtime.createNumber(4)
       ));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 4)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 4)"));
     }
   }
 
@@ -171,8 +171,8 @@ public class FunctionTest {
     try {
       typeOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 0)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 0)"));
     }
     try {
       typeOfFunction.call(runtime, createValueArguments(
@@ -180,8 +180,8 @@ public class FunctionTest {
         runtime.createNumber(3)
       ));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 2)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 2)"));
     }
   }
 
@@ -319,8 +319,8 @@ public class FunctionTest {
     try {
       arrayOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 0)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 0)"));
     }
     try {
       arrayOfFunction.call(runtime, createValueArguments(
@@ -328,8 +328,8 @@ public class FunctionTest {
         runtime.createNumber(3)
       ));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 2)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 2)"));
     }
   }
 
@@ -426,8 +426,8 @@ public class FunctionTest {
     try {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull()));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\" (expected at least 3 but was 1)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"hello\" (expected at least 3 but was 1)"));
     }
   }
 
@@ -440,8 +440,8 @@ public class FunctionTest {
     try {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull(), runtime.createNull(), runtime.createNull(), runtime.createNull()));
       fail("No exception was thrown");
-    } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\" (expected at most 3 but was 4)"));
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage(), containsString("Invalid arity calling \"hello\" (expected at most 3 but was 4)"));
     }
   }
 

--- a/jmespath-core/src/test/java/io/burt/jmespath/jcf/JcfTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/jcf/JcfTest.java
@@ -7,16 +7,15 @@ import java.util.Collections;
 import org.junit.Test;
 
 import io.burt.jmespath.JmesPathRuntimeTest;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.Adapter;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class JcfTest extends JmesPathRuntimeTest<Object> {
-  private Adapter<Object> runtime = new JcfRuntime();
-
   @Override
-  protected Adapter<Object> runtime() { return runtime; }
+  protected Adapter<Object> createRuntime(RuntimeConfiguration configuration) { return new JcfRuntime(configuration); }
 
   @Test
   public void toListReturnsAListWhenGivenAnotherTypeOfCollection() {

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.jcf.JcfRuntime;
 import io.burt.jmespath.node.CreateObjectNode;
 import io.burt.jmespath.node.Node;
@@ -1203,11 +1204,11 @@ public class ParserTest {
 
   @Test
   public void callingAVariableArityFunctionWithTooManyArgumentsThrowsParseException() {
-    runtime = new JcfRuntime(FunctionRegistry.defaultRegistry().extend(
+    runtime = new JcfRuntime(RuntimeConfiguration.builder().withFunctionRegistry(FunctionRegistry.defaultRegistry().extend(
       new BaseFunction("foobar", ArgumentConstraints.listOf(1, 3, ArgumentConstraints.anyValue())) {
         protected <T> T callFunction(Adapter<T> runtime, List<FunctionArgument<T>> arguments) { return runtime.createNull(); }
       }
-    ));
+    )).build());
     try {
       compile("foobar(a, b, c, d, e, f, g)");
       fail("Expected ParseException to have been thrown");

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -3,7 +3,6 @@ package io.burt.jmespath.parser;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.burt.jmespath.Adapter;

--- a/jmespath-gson/src/main/java/io/burt/jmespath/gson/GsonRuntime.java
+++ b/jmespath-gson/src/main/java/io/burt/jmespath/gson/GsonRuntime.java
@@ -8,8 +8,8 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
 import io.burt.jmespath.BaseRuntime;
-import io.burt.jmespath.function.FunctionRegistry;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.RuntimeConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -20,13 +20,13 @@ import java.util.Map;
 public class GsonRuntime extends BaseRuntime<JsonElement> {
   private final JsonParser parser;
 
-  public GsonRuntime(FunctionRegistry functionRegistry) {
-    super(functionRegistry);
-    this.parser = new JsonParser();
+  public GsonRuntime() {
+    this(RuntimeConfiguration.defaultConfiguration());
   }
 
-  public GsonRuntime() {
-    this(null);
+  public GsonRuntime(RuntimeConfiguration configuration) {
+    super(configuration);
+    this.parser = new JsonParser();
   }
 
   @Override

--- a/jmespath-gson/src/test/java/io/burt/jmespath/gson/GsonTest.java
+++ b/jmespath-gson/src/test/java/io/burt/jmespath/gson/GsonTest.java
@@ -3,12 +3,9 @@ package io.burt.jmespath.gson;
 import com.google.gson.JsonElement;
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.JmesPathRuntimeTest;
+import io.burt.jmespath.RuntimeConfiguration;
 
 public class GsonTest extends JmesPathRuntimeTest<JsonElement> {
-    private Adapter<JsonElement> runtime = new GsonRuntime();
-
-    @Override
-    protected Adapter<JsonElement> runtime() {
-        return runtime;
-    }
+  @Override
+  protected Adapter<JsonElement> createRuntime(RuntimeConfiguration configuration) { return new GsonRuntime(configuration); }
 }

--- a/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
+++ b/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
@@ -16,17 +16,18 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.burt.jmespath.BaseRuntime;
 import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.function.FunctionRegistry;
 
 public class JacksonRuntime extends BaseRuntime<JsonNode> {
   private final ObjectMapper jsonParser;
 
   public JacksonRuntime() {
-    this(null);
+    this(RuntimeConfiguration.defaultConfiguration());
   }
 
-  public JacksonRuntime(FunctionRegistry functionRegistry) {
-    super(functionRegistry);
+  public JacksonRuntime(RuntimeConfiguration configuration) {
+    super(configuration);
     this.jsonParser = new ObjectMapper();
   }
 

--- a/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
+++ b/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.burt.jmespath.BaseRuntime;
 import io.burt.jmespath.JmesPathType;
 import io.burt.jmespath.RuntimeConfiguration;
-import io.burt.jmespath.function.FunctionRegistry;
 
 public class JacksonRuntime extends BaseRuntime<JsonNode> {
   private final ObjectMapper jsonParser;

--- a/jmespath-jackson/src/test/java/io/burt/jmespath/jackson/JacksonTest.java
+++ b/jmespath-jackson/src/test/java/io/burt/jmespath/jackson/JacksonTest.java
@@ -3,11 +3,10 @@ package io.burt.jmespath.jackson;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.burt.jmespath.JmesPathRuntimeTest;
+import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.Adapter;
 
 public class JacksonTest extends JmesPathRuntimeTest<JsonNode> {
-  private Adapter<JsonNode> runtime = new JacksonRuntime();
-
   @Override
-  protected Adapter<JsonNode> runtime() { return runtime; }
+  protected Adapter<JsonNode> createRuntime(RuntimeConfiguration configuration) { return new JacksonRuntime(configuration); }
 }


### PR DESCRIPTION
This builds on #27, and on discussions (by me) in #23 and #24: I think there's a need to make the type checker configurable. It's pretty crazy that `foo.bar.baz` with `null` as input is perfectly fine, but `to_string(@)` is not. It's both inconsistent and a hassle to have to deal with, but also a big performance issue. Having to guard against `ArgumentTypeException` every time you evaluate an expression is annoying, and if you're evaluating the same expression thousands of times per second on input that could potentially create a `null` value somewhere, you really don't want exceptions to be thrown.

By removing the internal exception throwing from the type checker the next step should be much easier. It should be possible to, for example, introduce a configuration parameter that instead of throwing `ArgumentTypeException` makes the function call expression result in `null`. We added this feature to jmespath.rb, and it had a huge performance impact, see burtcorp/burtpath#2.

I'm not sure that that is the way we should go with jmespath-java, though, we might have something more fine grained that made functions deal with `null` in natural ways (like treating it like an empty list, for example), but that's for another PR.
