### PR TITLE
Check function arity at compile/parse time

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArgumentConstraint.java
@@ -18,21 +18,21 @@ public interface ArgumentConstraint {
    * @throws ArityException when there are not enough arguments left to satisfy the constraint
    * @throws ArgumentTypeException when an argument does not satisfy the constraint
    */
-  public <T> void check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments);
+  <T> void check(Adapter<T> runtime, Iterator<FunctionArgument<T>> arguments);
 
   /**
    * @return the minimum number of arguments required.
    */
-  public int minArity();
+  int minArity();
 
   /**
    * @return the maximum number of arguments accepted.
    */
-  public int maxArity();
+  int maxArity();
 
   /**
    * @return a string representation of the types accepted. Used to construct
    *   user friendly error messages.
    */
-  public String expectedType();
+  String expectedType();
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/ArityException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/ArityException.java
@@ -2,21 +2,31 @@ package io.burt.jmespath.function;
 
 @SuppressWarnings("serial")
 public class ArityException extends FunctionCallException {
-  public ArityException(String functionName, int minArity, int maxArity, int numArguments) {
-    this(functionName, minArity, maxArity, numArguments, null);
+  public ArityException(Function function, int numArguments) {
+    this(function, numArguments, null);
   }
 
-  public ArityException(String functionName, int minArity, int maxArity, int numArguments, Throwable cause) {
-    super(createMessage(functionName, minArity, maxArity, numArguments), cause);
+  public ArityException(Function function, int numArguments, Throwable cause) {
+    super(createMessage(function, numArguments, true), cause);
   }
 
-  private static String createMessage(String functionName, int minArity, int maxArity, int numArguments) {
-    if (maxArity == minArity) {
-      return String.format("Invalid arity calling \"%s\": expected %d but was %d", functionName, minArity, numArguments);
-    } else if (numArguments < minArity) {
-      return String.format("Invalid arity calling \"%s\": expected at least %d but was %d", functionName, minArity, numArguments);
+  public static String createMessage(Function function, int numArguments, boolean initialUppercase) {
+    int minArity = function.argumentConstraints().minArity();
+    int maxArity = function.argumentConstraints().maxArity();
+    StringBuilder buffer = new StringBuilder();
+    if (initialUppercase) {
+      buffer.append("Invalid");
     } else {
-      return String.format("Invalid arity calling \"%s\": expected at most %d but was %d", functionName, maxArity, numArguments);
+      buffer.append("invalid");
     }
+    buffer.append(" arity calling \"").append(function.name()).append("\"");
+    if (maxArity == minArity) {
+      buffer.append(String.format(" (expected %d but was %d)", minArity, numArguments));
+    } else if (numArguments < minArity) {
+      buffer.append(String.format(" (expected at least %d but was %d)", minArity, numArguments));
+    } else {
+      buffer.append(String.format(" (expected at most %d but was %d)", maxArity, numArguments));
+    }
+    return buffer.toString();
   }
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/BaseFunction.java
@@ -98,6 +98,11 @@ public abstract class BaseFunction implements Function {
     return name;
   }
 
+  @Override
+  public ArgumentConstraint argumentConstraints() {
+    return argumentConstraints;
+  }
+
   /**
    * Call this function with a list of arguments.
    *
@@ -121,10 +126,10 @@ public abstract class BaseFunction implements Function {
       Iterator<FunctionArgument<T>> argumentIterator = arguments.iterator();
       argumentConstraints.check(runtime, argumentIterator);
       if (argumentIterator.hasNext()) {
-        throw new ArityException(name(), argumentConstraints.minArity(), argumentConstraints.maxArity(), arguments.size());
+        throw new ArityException(this, arguments.size());
       }
     } catch (ArgumentConstraints.InternalArityException e) {
-      throw new ArityException(name(), argumentConstraints.minArity(), argumentConstraints.maxArity(), arguments.size(), e);
+      throw new ArityException(this, arguments.size(), e);
     } catch (ArgumentConstraints.InternalArgumentTypeException e) {
       throw new ArgumentTypeException(name(), e.expectedType(), e.actualType(), e);
     }

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/Function.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/Function.java
@@ -20,6 +20,12 @@ public interface Function {
   String name();
 
   /**
+   * Returns the constraints to use when checking the list of arguments before
+   * the function is called.
+   */
+  ArgumentConstraint argumentConstraints();
+
+  /**
    * Call this function with a list of arguments.
    * <p>
    * The arguments can be either values or expressions, and their types will be

--- a/jmespath-core/src/main/java/io/burt/jmespath/function/Function.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/Function.java
@@ -17,7 +17,7 @@ public interface Function {
    * The name is either automatically generated from the class name, or
    * explicitly specified in the constructor.
    */
-  public String name();
+  String name();
 
   /**
    * Call this function with a list of arguments.
@@ -28,5 +28,5 @@ public interface Function {
    * @throws ArgumentTypeException when the function is called with arguments of the wrong type
    * @throws ArityException when the function is called with the wrong number of arguments
    */
-  public <T> T call(Adapter<T> runtime, List<FunctionArgument<T>> arguments);
+  <T> T call(Adapter<T> runtime, List<FunctionArgument<T>> arguments);
 }

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ExpressionParser.java
@@ -10,6 +10,8 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import io.burt.jmespath.Expression;
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.function.Function;
+import io.burt.jmespath.function.ArgumentConstraint;
+import io.burt.jmespath.function.ArityException;
 import io.burt.jmespath.util.StringEscapeHelper;
 import io.burt.jmespath.util.AntlrHelper;
 import io.burt.jmespath.node.NodeFactory;
@@ -296,6 +298,13 @@ public class ExpressionParser<T> extends JmesPathBaseVisitor<Node<T>> {
     if (implementation == null) {
       Token token = ctx.NAME().getSymbol();
       errors.parseError(String.format("unknown function \"%s\"", name), token.getStartIndex());
+    } else {
+      ArgumentConstraint argumentConstraints = implementation.argumentConstraints();
+      if (n < argumentConstraints.minArity() || n > argumentConstraints.maxArity()) {
+        Token token = ctx.NAME().getSymbol();
+        String message = ArityException.createMessage(implementation, n, false);
+        errors.parseError(message, token.getStartIndex());
+      }
     }
     return createSequenceIfChained(nodeFactory.createFunctionCall(implementation, args));
   }

--- a/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/function/FunctionTest.java
@@ -117,7 +117,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\": expected 3 but was 2"));
+      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 2)"));
     }
   }
 
@@ -132,7 +132,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\": expected 3 but was 4"));
+      assertThat(ae.getMessage(), is("Invalid arity calling \"heterogenous_list\" (expected 3 but was 4)"));
     }
   }
 
@@ -172,7 +172,7 @@ public class FunctionTest {
       typeOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\": expected 1 but was 0"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 0)"));
     }
     try {
       typeOfFunction.call(runtime, createValueArguments(
@@ -181,7 +181,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\": expected 1 but was 2"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"type_of\" (expected 1 but was 2)"));
     }
   }
 
@@ -320,7 +320,7 @@ public class FunctionTest {
       arrayOfFunction.call(runtime, createValueArguments());
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\": expected 1 but was 0"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 0)"));
     }
     try {
       arrayOfFunction.call(runtime, createValueArguments(
@@ -329,7 +329,7 @@ public class FunctionTest {
       ));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\": expected 1 but was 2"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"array_of\" (expected 1 but was 2)"));
     }
   }
 
@@ -427,7 +427,7 @@ public class FunctionTest {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull()));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\": expected at least 3 but was 1"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\" (expected at least 3 but was 1)"));
     }
   }
 
@@ -441,7 +441,7 @@ public class FunctionTest {
       acceptsBetweenThreeAndTenValues.call(runtime, createValueArguments(runtime.createNull(), runtime.createNull(), runtime.createNull(), runtime.createNull()));
       fail("No exception was thrown");
     } catch (ArityException ae) {
-      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\": expected at most 3 but was 4"));
+      assertThat(ae.getMessage(), containsString("Invalid arity calling \"hello\" (expected at most 3 but was 4)"));
     }
   }
 


### PR DESCRIPTION
We have all the information we need to check function call arity at compile time. This can avoid runtime errors, which is almost always a good thing. The runtime type checker still checks arity, because it really can't not or risk NPEs, but in practice there should be no arity exceptions at runtime with this code.