### PR TITLE
Let one pass an external ObjectMapper to JacksonRuntime instance

### DIFF
--- a/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
+++ b/jmespath-jackson/src/main/java/io/burt/jmespath/jackson/JacksonRuntime.java
@@ -26,8 +26,12 @@ public class JacksonRuntime extends BaseRuntime<JsonNode> {
   }
 
   public JacksonRuntime(RuntimeConfiguration configuration) {
+    this(configuration, new ObjectMapper());
+  }
+
+  public JacksonRuntime(RuntimeConfiguration configuration, ObjectMapper jsonParser) {
     super(configuration);
-    this.jsonParser = new ObjectMapper();
+    this.jsonParser = jsonParser;
   }
 
   @Override


### PR DESCRIPTION
Motivation:

JacksonRuntime currently creates it own internal ObjectMapper instance.
This ObjectMapper is used for parsing JSON String an emitting JsonLiteral instances.

Jackson provides lots of features, see https://static.javadoc.io/com.fasterxml.jackson.core/jackson-core/2.9.9/com/fasterxml/jackson/core/JsonParser.Feature.html.
Users might want to provide their own ObjectMapper instance configured for their needs (allowing numeric leading zeros, custom date formats, etc) or simply because they already have an instance and there's no reason the create a second one.

Modification:

Add a new constructor.

Result:

Users can provide their own ObjectMapper instance.