### PR TITLE
Reduce StringEscapeHelper escape and unescape allocations

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/util/StringEscapeHelper.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/util/StringEscapeHelper.java
@@ -43,7 +43,7 @@ public class StringEscapeHelper {
     int slashIndex = str.indexOf('\\');
     if (slashIndex > -1) {
       int offset = 0;
-      StringBuilder unescaped = new StringBuilder();
+      StringBuilder unescaped = new StringBuilder(str.length() - 1);
       while (slashIndex > -1) {
         char c = str.charAt(slashIndex + 1);
         char r = (c < unescapeMap.length) ? unescapeMap[c] : NO_REPLACEMENT;
@@ -68,17 +68,23 @@ public class StringEscapeHelper {
   }
 
   public String escape(String str) {
-    StringBuilder escaped = new StringBuilder();
+    StringBuilder escaped = null;
     int offset = 0;
     for (int i = 0; i < str.length(); i++) {
       char c = str.charAt(i);
       char r = (c < escapeMap.length) ? escapeMap[c] : NO_REPLACEMENT;
       if (r != NO_REPLACEMENT) {
+        if (escaped == null) {
+          escaped = new StringBuilder(str.length() + 1);
+        }
         escaped.append(str, offset, i);
         escaped.append('\\');
         escaped.append(r);
         offset = i + 1;
       }
+    }
+    if (escaped == null) {
+      return str;
     }
     if (offset < str.length()) {
       escaped.append(str, offset, str.length());

--- a/jmespath-core/src/test/java/io/burt/jmespath/util/StringEscapeHelperTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/util/StringEscapeHelperTest.java
@@ -52,4 +52,15 @@ public class StringEscapeHelperTest {
     String escaped = escapeHelper.escape("\thello\nworld!");
     assertThat(escaped, is("\\thello\\nworld\\x"));
   }
+
+  @Test
+  public void stringWithoutSpecialCharsIsNotModified() {
+    StringEscapeHelper escapeHelper = new StringEscapeHelper(
+      'n', '\n',
+      't', '\t',
+      'x', '!'
+    );
+    String escaped = escapeHelper.escape("hello world");
+    assertThat(escaped, is("hello world"));
+  }
 }


### PR DESCRIPTION
Motivation:

* StringEscapeHelper allocates StringBuilder of default size (16) so there's a good chance it will either be too large, or too small and reallocate underlying char array.
* escaped always allocate StringBuilder, even when there's nothing to escape in the input String.

Modifications:

* Set StringBuilder initial capacity
* lazy allocate escape's StringBuilder

Result:

Less allocations.