### PR TITLE
Maven explicit encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <jackson.version>2.9.9</jackson.version>
     <gson.version>2.8.5</gson.version>
     <antlr.version>4.7.2</antlr.version>
+    <encoding>UTF-8</encoding>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Motivation:

Maven issues warnings because resources encoding is not specified, hence uses platform default encoding and build is platform dependent.

Modification:

Use explicit UTF-8 encoding.

Result:

Build is not platform dependent.