### PR TITLE
Optimize StringBuilder based loops

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/node/CreateArrayNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/CreateArrayNode.java
@@ -2,7 +2,6 @@ package io.burt.jmespath.node;
 
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
@@ -21,7 +20,7 @@ public class CreateArrayNode<T> extends Node<T> {
     if (runtime.typeOf(input) == JmesPathType.NULL) {
       return input;
     } else {
-      List<T> array = new ArrayList<>();
+      List<T> array = new ArrayList<>(entries.size());
       for (Expression<T> entry : entries) {
         array.add(entry.search(input));
       }
@@ -31,17 +30,15 @@ public class CreateArrayNode<T> extends Node<T> {
 
   @Override
   protected String internalToString() {
-    StringBuilder str = new StringBuilder("[");
-    Iterator<Expression<T>> entryIterator = entries.iterator();
-    while (entryIterator.hasNext()) {
-      Expression<T> entry = entryIterator.next();
-      str.append(entry);
-      if (entryIterator.hasNext()) {
-        str.append(", ");
-      }
+    if (entries.isEmpty()) {
+      return "[]";
     }
-    str.append(']');
-    return str.toString();
+    StringBuilder str = new StringBuilder("[");
+    for (Expression<T> entry : entries) {
+      str.append(entry).append(", ");
+    }
+    str.setLength(str.length() - 2);
+    return str.append(']').toString();
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/CreateObjectNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/CreateObjectNode.java
@@ -3,7 +3,6 @@ package io.burt.jmespath.node;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Iterator;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
@@ -70,17 +69,15 @@ public class CreateObjectNode<T> extends Node<T> {
 
   @Override
   protected String internalToString() {
-    StringBuilder str = new StringBuilder("{");
-    Iterator<Entry<T>> entryIterator = entries.iterator();
-    while (entryIterator.hasNext()) {
-      Entry<T> entry = entryIterator.next();
-      str.append(entry.key()).append('=').append(entry.value());
-      if (entryIterator.hasNext()) {
-        str.append(", ");
-      }
+    if (entries.isEmpty()) {
+      return "{}";
     }
-    str.append('}');
-    return str.toString();
+    StringBuilder str = new StringBuilder("{");
+    for (Entry<T> entry : entries) {
+      str.append(entry.key()).append('=').append(entry.value()).append(", ");
+    }
+    str.setLength(str.length() - 2);
+    return str.append('}').toString();
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/FunctionCallNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/FunctionCallNode.java
@@ -2,7 +2,6 @@ package io.burt.jmespath.node;
 
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
@@ -39,16 +38,13 @@ public class FunctionCallNode<T> extends Node<T> {
       str.append(implementation.name());
     }
     str.append(", [");
-    Iterator<Expression<T>> argIterator = args.iterator();
-    while (argIterator.hasNext()) {
-      Expression<T> arg = argIterator.next();
-      str.append(arg);
-      if (argIterator.hasNext()) {
-        str.append(", ");
-      }
+    for (Expression<T> arg : args) {
+      str.append(arg).append(", ");
     }
-    str.append(']');
-    return str.toString();
+    if (!args.isEmpty()) {
+      str.setLength(str.length() - 2);
+    }
+    return str.append(']').toString();
   }
 
   @Override

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/Node.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/Node.java
@@ -19,7 +19,7 @@ public abstract class Node<T> implements Expression<T> {
     StringBuilder str = new StringBuilder();
     String name = getClass().getName();
     str.append(name.substring(name.lastIndexOf('.') + 1));
-    str.delete(str.length() - 4, str.length());
+    str.setLength(str.length() - 4);
     str.append('(');
     if (extraArgs != null) {
       str.append(extraArgs);

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/OperatorNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/OperatorNode.java
@@ -2,7 +2,6 @@ package io.burt.jmespath.node;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Iterator;
 
 import io.burt.jmespath.Adapter;
 import io.burt.jmespath.Expression;
@@ -22,15 +21,14 @@ public abstract class OperatorNode<T> extends Node<T> {
 
   @Override
   protected String internalToString() {
-    StringBuilder operandsString = new StringBuilder();
-    Iterator<Expression<T>> operandIterator = operands.iterator();
-    while (operandIterator.hasNext()) {
-      Expression<T> operand = operandIterator.next();
-      operandsString.append(operand);
-      if (operandIterator.hasNext()) {
-        operandsString.append(", ");
-      }
+    if (operands.isEmpty()) {
+      return "";
     }
+    StringBuilder operandsString = new StringBuilder();
+    for (Expression<T> operand : operands) {
+      operandsString.append(operand).append(", ");
+    }
+    operandsString.setLength(operandsString.length() - 2);
     return operandsString.toString();
   }
 

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/SequenceNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/SequenceNode.java
@@ -1,6 +1,5 @@
 package io.burt.jmespath.node;
 
-import java.util.Iterator;
 import java.util.List;
 
 import io.burt.jmespath.Adapter;
@@ -19,12 +18,10 @@ public class SequenceNode<T> extends Node<T> {
       return null;
     } else {
       StringBuilder buffer = new StringBuilder();
-      Iterator<Node<T>> iterator = nodes.iterator();
-      buffer.append(iterator.next());
-      while (iterator.hasNext()) {
-        buffer.append(", ");
-        buffer.append(iterator.next());
+      for (Node<T> node : nodes) {
+        buffer.append(node).append(", ");
       }
+      buffer.setLength(buffer.length() - 2);
       return buffer.toString();
     }
   }

--- a/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseException.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/parser/ParseException.java
@@ -16,9 +16,9 @@ public class ParseException extends JmesPathException implements Iterable<ParseE
   private static String joinMessages(Iterable<ParseError> errors) {
     StringBuilder s = new StringBuilder();
     for (ParseError e : errors) {
-      s.append(String.format(", %s at position %d", e.message(), e.position()));
+      s.append(String.format("%s at position %d, ", e.message(), e.position()));
     }
-    s.delete(0, 2);
+    s.setLength(s.length() - 2);
     return s.toString();
   }
 


### PR DESCRIPTION
Motivation:

Nodes' internalToString and ParseExceptions uses StringBuilder based loops. Even tough those shouldn't be on the hot path if Expressions are cached, they still can be optimized.

Modifications:

Stop using Iterators with nested hasNext tests. Use simple for loops that have a chance of being JIT'ed with escape analysis.
Don't test last element in loop (cf above). Update StringBuilder's length after loop if it wasn't empty.
Don't use StringBuilder#delete that causes a copy of the underlying char array. Update StringBuilder's length instead as we always want to remove the tail.
Result:

Less allocations