### PR TITLE
Fix parsing for boolean expressions starting with negation

### DIFF
--- a/jmespath-core/src/main/antlr4/io/burt/jmespath/parser/JmesPath.g4
+++ b/jmespath-core/src/main/antlr4/io/burt/jmespath/parser/JmesPath.g4
@@ -7,10 +7,10 @@ expression
   | expression bracketSpecifier # bracketedExpression
   | bracketSpecifier # bracketExpression
   | expression COMPARATOR expression # comparisonExpression
+  | '!' expression # notExpression
   | expression '&&' expression # andExpression
   | expression '||' expression # orExpression
   | identifier # identifierExpression
-  | '!' expression # notExpression
   | '(' expression ')' # parenExpression
   | wildcard # wildcardExpression
   | multiSelectList # multiSelectListExpression

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -806,6 +806,32 @@ public class ParserTest {
   }
 
   @Test
+  public void negatedBooleansTripleConjunctionExpression() {
+    Expression<Object> expected = And(
+        And(
+            Negate(Property("foo")),
+            Negate(Property("bar"))
+        ),
+        Negate(Property("buzz"))
+    );
+    Expression<Object> actual = compile("!foo && !bar && !buzz");
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  public void negatedBooleansTripleDisjunctionExpression() {
+    Expression<Object> expected = Or(
+        Or(
+            Negate(Property("foo")),
+            Negate(Property("bar"))
+        ),
+        Negate(Property("buzz"))
+    );
+    Expression<Object> actual = compile("!foo || !bar || !buzz");
+    assertThat(actual, is(expected));
+  }
+
+  @Test
   public void negatedSelectionExpression() {
     Expression<Object> expected = Sequence(
       Property("foo"),


### PR DESCRIPTION
Fixed antlr grammar to correctly resolve boolean expressions starting with negation.
**Before fix:**
Expression `!True && False`:

- would resolve to `true` which is wrong.
- antlr would parse it to: `Negate(And(Property("True"), Property("False")))`

**After fix:**
Expression `!True && False`:

- would resolve to `false` as expected.
- antlr would parse it to: `And(Negate(Property("True")), Property("False"))`

Also created [PR](https://github.com/jmespath/jmespath.test/pull/22) to update compliance tests. 
Issue link: #65 