### PR TITLE
Fix precedence of negation vs comparison

### DIFF
--- a/jmespath-core/src/main/antlr4/io/burt/jmespath/parser/JmesPath.g4
+++ b/jmespath-core/src/main/antlr4/io/burt/jmespath/parser/JmesPath.g4
@@ -6,8 +6,8 @@ expression
   : expression '.' chainedExpression # chainExpression
   | expression bracketSpecifier # bracketedExpression
   | bracketSpecifier # bracketExpression
-  | expression COMPARATOR expression # comparisonExpression
   | '!' expression # notExpression
+  | expression COMPARATOR expression # comparisonExpression
   | expression '&&' expression # andExpression
   | expression '||' expression # orExpression
   | identifier # identifierExpression

--- a/jmespath-core/src/main/java/io/burt/jmespath/node/NegateNode.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/node/NegateNode.java
@@ -23,6 +23,11 @@ public class NegateNode<T> extends Node<T> {
   }
 
   @Override
+  protected String internalToString() {
+    return negated.toString();
+  }
+
+  @Override
   protected int internalHashCode() {
     return 17 + 31 * negated.hashCode();
   }

--- a/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/parser/ParserTest.java
@@ -844,6 +844,17 @@ public class ParserTest {
   }
 
   @Test
+  public void negatedComparison() {
+    Expression<Object> expected = Comparison(
+      "==",
+      Negate(Property("foo")),
+      JsonLiteral("false")
+    );
+    Expression<Object> actual = compile("!foo == `false`");
+    assertThat(actual, is(expected));
+  }
+
+  @Test
   public void bareJsonLiteralExpression() {
     Expression<Object> expected = JsonLiteral("{}");
     Expression<Object> actual = compile("`{}`");


### PR DESCRIPTION
Fixed antlr grammar to correctly prioritize negation vs comparison when parsing.

Before fix, expression `!foo == 'bar'` was parsed into:
```
Negate(Comparison(==, Property(Foo), String(bar)))
```

After fix, expression `!foo == 'bar'` is parsed into:
```
Comparison(==, Negate(Property(Foo)), String(bar))
```

Taking the JS implementation as the source of truth, because it prioritizes negation vs comparison. Example:
```
search(!foo == `true`, {"foo":1}) // false
```
First `foo` (which is equal to 1) is negated, resulting in `false`. Then, the result is compared to `true`, so the final result is `false`. Before the fix, this Java implementation would return `true` for the same expression, because first foo is compared to `true`, which results in `false` (because `1 != true`) and the result is negated, resulting in `true`.